### PR TITLE
Fix syntax error in interactions dialogue call

### DIFF
--- a/src/scripts/interactions.js
+++ b/src/scripts/interactions.js
@@ -77,7 +77,7 @@ function giveItemToBedouins({
         dialogueElement,
         'Wonderful, we can start making the tea now.',
         false,
-        12000,
+        12000
       );
     } else {
       showDialogue(dialogueElement, 'Nice.', false, 3000);


### PR DESCRIPTION
## Summary
- remove the trailing comma in the long dialogue showDialogue call to avoid syntax errors in environments that disallow it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e646db5780832b9b020ffd67c8e32a