### PR TITLE
Make scene layout responsive with data-driven positioning

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,22 +8,22 @@
 </head>
 <body>
   <div id="game">
-    <div class="ambient" style="top:5%;left:3%">dunes</div>
-    <div class="ambient" style="top:6%;left:15%">more dunes</div>
-    <div class="ambient" style="top:7%;left:35%">dunes</div>
-    <div class="ambient" style="top:5%;left:55%">more dunes</div>
-    <div class="ambient" style="top:6%;left:75%">dunes</div>
-    <div class="ambient" style="top:7%;left:90%">more dunes</div>
-    <div class="ambient" style="top:9%;left:10%">dunes</div>
-    <div class="ambient" style="top:10%;left:40%">more dunes</div>
-    <div class="ambient" style="top:9%;left:70%">dunes</div>
+    <div class="ambient" data-ambient="dunes-west-1">dunes</div>
+    <div class="ambient" data-ambient="dunes-west-2">more dunes</div>
+    <div class="ambient" data-ambient="dunes-mid-1">dunes</div>
+    <div class="ambient" data-ambient="dunes-mid-2">more dunes</div>
+    <div class="ambient" data-ambient="dunes-east-1">dunes</div>
+    <div class="ambient" data-ambient="dunes-east-2">more dunes</div>
+    <div class="ambient" data-ambient="dunes-south-1">dunes</div>
+    <div class="ambient" data-ambient="dunes-south-2">more dunes</div>
+    <div class="ambient" data-ambient="dunes-south-3">dunes</div>
 
-    <div class="label" data-name="palm tree" style="font-size:3rem;width:100px;height:500px;top:calc(70% + 140px - 500px);left:5%">palm tree</div>
-    <div class="label" data-name="carpet" style="font-size:2rem;width:300px;height:140px;top:70%;left:18%;z-index:1">carpet</div>
-    <div class="label" data-name="bedouins" style="font-size:2rem;width:300px;height:80px;left:20%;top:58%;background:#f4e3c2;z-index:2">bedouins</div>
-    <div class="label" data-name="camel" style="font-size:2rem;top:28%;left:60%;background:#e2b980;color:#2a1b0a">camel</div>
-    <div class="label" data-name="pond" style="font-size:2rem;width:200px;height:60px;top:38%;left:65%">pond</div>
-    <div class="label" data-name="bucket" style="font-size:0.6rem;width:16px;height:32px;top:30%;left:77%">bucket</div>
+    <div class="label" data-name="palm tree">palm tree</div>
+    <div class="label" data-name="carpet">carpet</div>
+    <div class="label" data-name="bedouins">bedouins</div>
+    <div class="label" data-name="camel">camel</div>
+    <div class="label" data-name="pond">pond</div>
+    <div class="label" data-name="bucket">bucket</div>
     <div class="label" data-name="me">ME</div>
     <div class="dialogue-box dialogue-me" id="dialogue-me"></div>
     <div class="dialogue-box dialogue-other" id="dialogue-bedouins"></div>

--- a/src/scripts/layout.js
+++ b/src/scripts/layout.js
@@ -1,0 +1,210 @@
+const layoutModes = [
+  { name: 'mobile', query: '(max-width: 768px)' },
+];
+
+const sceneLayout = {
+  ambients: [
+    { id: 'dunes-west-1', position: { default: { x: 0.03, y: 0.05 } }, fontScale: 1 },
+    { id: 'dunes-west-2', position: { default: { x: 0.15, y: 0.06 } } },
+    { id: 'dunes-mid-1', position: { default: { x: 0.35, y: 0.07 } } },
+    { id: 'dunes-mid-2', position: { default: { x: 0.55, y: 0.05 } } },
+    { id: 'dunes-east-1', position: { default: { x: 0.75, y: 0.06 } } },
+    { id: 'dunes-east-2', position: { default: { x: 0.9, y: 0.07 } } },
+    { id: 'dunes-south-1', position: { default: { x: 0.1, y: 0.09 } } },
+    { id: 'dunes-south-2', position: { default: { x: 0.4, y: 0.1 } } },
+    { id: 'dunes-south-3', position: { default: { x: 0.7, y: 0.09 } } },
+  ],
+  labels: {
+    'palm tree': {
+      position: {
+        default: { x: 0.08, y: 0.24 },
+        mobile: { x: 0.12, y: 0.3 },
+      },
+      size: {
+        width: { default: 0.12, mobile: 0.16 },
+        height: { default: 0.6, mobile: 0.58 },
+      },
+      fontScale: { default: 2.2, mobile: 1.9 },
+      layer: 4,
+    },
+    carpet: {
+      position: { default: { x: 0.33, y: 0.76 }, mobile: { x: 0.35, y: 0.78 } },
+      size: {
+        width: { default: 0.32, mobile: 0.4 },
+        height: { default: 0.16, mobile: 0.18 },
+      },
+      fontScale: { default: 1.6, mobile: 1.4 },
+      layer: 1,
+    },
+    bedouins: {
+      position: { default: { x: 0.32, y: 0.6 }, mobile: { x: 0.35, y: 0.62 } },
+      size: {
+        width: { default: 0.32, mobile: 0.44 },
+        height: { default: 0.12, mobile: 0.14 },
+      },
+      fontScale: { default: 1.5, mobile: 1.35 },
+      layer: 2,
+    },
+    camel: {
+      position: { default: { x: 0.65, y: 0.34 }, mobile: { x: 0.6, y: 0.32 } },
+      fontScale: { default: 1.5, mobile: 1.4 },
+      layer: 3,
+    },
+    pond: {
+      position: { default: { x: 0.75, y: 0.42 }, mobile: { x: 0.7, y: 0.46 } },
+      size: {
+        width: { default: 0.22, mobile: 0.28 },
+        height: { default: 0.1, mobile: 0.12 },
+      },
+      fontScale: { default: 1.4, mobile: 1.3 },
+      layer: 2,
+    },
+    bucket: {
+      position: { default: { x: 0.84, y: 0.36 }, mobile: { x: 0.8, y: 0.38 } },
+      size: {
+        width: {
+          default: 'clamp(16px, 3vw, 28px)',
+          mobile: 'clamp(18px, 6vw, 28px)',
+        },
+        height: {
+          default: 'clamp(32px, 6vw, 56px)',
+          mobile: 'clamp(36px, 10vw, 64px)',
+        },
+      },
+      fontScale: { default: 0.55, mobile: 0.6 },
+      layer: 2,
+    },
+  },
+};
+
+const mediaQueries = layoutModes.map((mode) => ({
+  ...mode,
+  matcher: typeof window !== 'undefined' ? window.matchMedia(mode.query) : null,
+}));
+
+const styleElementId = 'scene-layout-styles';
+let listenersBound = false;
+
+function getActiveMode() {
+  const active = mediaQueries.find((mode) => mode.matcher && mode.matcher.matches);
+  return active ? active.name : 'default';
+}
+
+function resolveResponsiveValue(value, mode) {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+
+  if (value[mode] != null) {
+    return value[mode];
+  }
+
+  if (value.default != null) {
+    return value.default;
+  }
+
+  if (value.base != null) {
+    return value.base;
+  }
+
+  const firstKey = Object.keys(value)[0];
+  return value[firstKey];
+}
+
+function resolvePosition(position, mode) {
+  const resolved = resolveResponsiveValue(position, mode);
+  if (!resolved) {
+    return { x: 0, y: 0 };
+  }
+  return resolved;
+}
+
+function formatDimension(value, mode) {
+  const resolved = resolveResponsiveValue(value, mode);
+  if (resolved == null) {
+    return null;
+  }
+  if (typeof resolved === 'number') {
+    return `calc(${resolved} * 100%)`;
+  }
+  return resolved;
+}
+
+function renderSceneLayout(gameElement) {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const mode = getActiveMode();
+  let styleElement = document.getElementById(styleElementId);
+
+  if (!styleElement) {
+    styleElement = document.createElement('style');
+    styleElement.id = styleElementId;
+    document.head.appendChild(styleElement);
+  }
+
+  const rules = [];
+
+  sceneLayout.ambients.forEach((ambient) => {
+    const position = resolvePosition(ambient.position, mode);
+    const fontScale = resolveResponsiveValue(ambient.fontScale, mode);
+    const declarations = [
+      `--pos-x: ${position.x}`,
+      `--pos-y: ${position.y}`,
+    ];
+    if (fontScale) {
+      declarations.push(`--font-scale: ${fontScale}`);
+    }
+    rules.push(`#game [data-ambient="${ambient.id}"] { ${declarations.join('; ')}; }`);
+  });
+
+  Object.entries(sceneLayout.labels).forEach(([name, config]) => {
+    const position = resolvePosition(config.position, mode);
+    const declarations = [
+      `--pos-x: ${position.x}`,
+      `--pos-y: ${position.y}`,
+    ];
+
+    if (config.size) {
+      const width = formatDimension(config.size.width, mode);
+      const height = formatDimension(config.size.height, mode);
+      if (width) {
+        declarations.push(`--size-width: ${width}`);
+      }
+      if (height) {
+        declarations.push(`--size-height: ${height}`);
+      }
+    }
+
+    const fontScale = resolveResponsiveValue(config.fontScale, mode);
+    if (fontScale) {
+      declarations.push(`--font-scale: ${fontScale}`);
+    }
+
+    if (config.layer) {
+      declarations.push(`--layer: ${config.layer}`);
+    }
+
+    rules.push(`#game .label[data-name="${name}"] { ${declarations.join('; ')}; }`);
+  });
+
+  styleElement.textContent = rules.join('\n');
+
+  if (!listenersBound) {
+    const rerender = () => renderSceneLayout(gameElement);
+    mediaQueries.forEach((mode) => {
+      if (mode.matcher) {
+        mode.matcher.addEventListener('change', rerender);
+      }
+    });
+    window.addEventListener('resize', rerender);
+    listenersBound = true;
+  }
+}
+
+export { renderSceneLayout, sceneLayout };

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -7,6 +7,7 @@ import {
   giveItemToBedouins,
 } from './interactions.js';
 import { shakePalmTree } from './scene.js';
+import { renderSceneLayout } from './layout.js';
 
 const dialogueMe = document.getElementById('dialogue-me');
 const dialogueBedouins = document.getElementById('dialogue-bedouins');
@@ -17,6 +18,8 @@ const camel = document.querySelector('[data-name="camel"]');
 const bucket = document.querySelector('[data-name="bucket"]');
 const palmTree = document.querySelector('[data-name="palm tree"]');
 const gameElement = document.getElementById('game');
+
+renderSceneLayout(gameElement);
 
 let selectedVerb = null;
 const verbs = document.querySelectorAll('.verb');

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2,24 +2,36 @@ body {
   margin: 0;
   font-family: 'Courier New', monospace;
   background: #c4b59a;
-  overflow: hidden;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-height: 100vh;
 }
 
 #game {
   position: relative;
-  width: 100vw;
-  height: 80vh;
+  width: min(100vw, 1100px);
+  max-height: 80vh;
+  aspect-ratio: 16 / 9;
   background: #c4b59a;
   overflow: hidden;
+  margin: 0 auto;
+  --scene-width: 100%;
+  --scene-height: 100%;
+  --ambient-font-base: clamp(0.9rem, 1vw + 0.3rem, 1.4rem);
+  --label-font-base: clamp(1rem, 1vw + 0.6rem, 2.4rem);
 }
 
 .ambient {
   position: absolute;
-  font-size: 1.1rem;
   font-weight: bold;
   color: #3d2f1a;
   opacity: 0.5;
   z-index: 0;
+  font-size: calc(var(--ambient-font-base) * var(--font-scale, 1));
+  top: calc(var(--pos-y, 0) * 100%);
+  left: calc(var(--pos-x, 0) * 100%);
 }
 
 .label {
@@ -28,7 +40,6 @@ body {
   padding: 4px 10px;
   cursor: pointer;
   user-select: none;
-  font-size: 1.2rem;
   box-shadow: 2px 2px 4px rgba(0, 0, 0, 0.3);
   display: flex;
   align-items: center;
@@ -36,7 +47,12 @@ body {
   background: white;
   color: black;
   transition: transform 0.2s;
-  z-index: 2;
+  font-size: calc(var(--label-font-base) * var(--font-scale, 1));
+  top: calc(var(--pos-y, 0) * 100%);
+  left: calc(var(--pos-x, 0) * 100%);
+  width: var(--size-width, max-content);
+  height: var(--size-height, max-content);
+  z-index: var(--layer, 2);
 }
 
 .label[data-name="me"] {
@@ -50,6 +66,16 @@ body {
   animation: dashPath 6s ease-in-out forwards;
   z-index: 3;
   transform: scale(0.3);
+}
+
+.label[data-name="bedouins"] {
+  background: #f4e3c2;
+  color: #4a3a17;
+}
+
+.label[data-name="camel"] {
+  background: #e2b980;
+  color: #2a1b0a;
 }
 
 @keyframes dashPath {
@@ -131,28 +157,35 @@ body {
   z-index: 2;
 }
 
-#inventory {
-  height: 5vh;
-  background: #eee2c4;
+#inventory,
+#verbs {
+  width: min(100vw, 1100px);
+  margin: 0 auto;
   border-top: 2px solid #000;
+}
+
+#inventory {
+  background: #eee2c4;
   display: flex;
   align-items: center;
-  padding-left: 10px;
-  font-size: 1rem;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  font-size: clamp(0.95rem, 0.6vw + 0.7rem, 1.15rem);
 }
 
 #verbs {
-  height: 10vh;
   display: flex;
   justify-content: center;
   align-items: center;
   background: #f1e7d0;
-  border-top: 2px solid #000;
+  padding: 0.75rem 1rem;
+  gap: 0.75rem;
+  font-size: clamp(1rem, 0.8vw + 0.6rem, 1.2rem);
 }
 
 .verb {
-  margin: 0 10px;
-  padding: 6px 12px;
+  margin: 0;
+  padding: 0.5rem 1rem;
   border: 1px solid black;
   background: white;
   cursor: pointer;
@@ -173,4 +206,53 @@ body {
   background: black;
   padding: 0 4px;
   border-radius: 3px;
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 0 1rem;
+  }
+
+  #game {
+    width: 100%;
+  }
+
+  #inventory {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+  }
+
+  #inventory-items {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  #verbs {
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .verb {
+    flex: 1 1 calc(50% - 0.5rem);
+    text-align: center;
+    padding: 0.65rem 0.75rem;
+    font-size: clamp(0.9rem, 2.2vw, 1.05rem);
+  }
+}
+
+@media (max-width: 480px) {
+  #game {
+    aspect-ratio: 4 / 5;
+  }
+
+  .label[data-name="me"] {
+    left: 45%;
+  }
+
+  .verb {
+    flex: 1 1 100%;
+  }
 }


### PR DESCRIPTION
## Summary
- replace inline styles for ambient and label elements with semantic data attributes and CSS variable driven layout rules
- introduce a responsive layout renderer that maps normalized scene coordinates to CSS custom properties
- refine global styles with aspect-ratio based scene sizing and mobile friendly inventory/verb panels, including adaptive typography

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e6460c78a8832b90cfc6dff83d67ea