### PR TITLE
Add talk interactions and reset verb selection

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,6 @@
     <div class="verb" data-verb="use">USE</div>
     <div class="verb" data-verb="pickup">PICK UP</div>
     <div class="verb" data-verb="give">GIVE</div>
-    <div class="verb" data-verb="open">OPEN</div>
   </div>
   <script type="module" src="scripts/main.js"></script>
 </body>

--- a/src/scripts/interactions.js
+++ b/src/scripts/interactions.js
@@ -2,6 +2,56 @@ import { getText } from './texts.js';
 
 export const interactions = [
   {
+    verb: 'talk',
+    target: 'bedouins',
+    conditions: [],
+    dialogues: {
+      awaitingWater: { speaker: 'bedouins', textKey: 'interactions.talk.bedouins.awaitingWater', duration: 5000 },
+      awaitingWaterWithDates: { speaker: 'bedouins', textKey: 'interactions.talk.bedouins.awaitingWaterWithDates', duration: 5500 },
+      awaitingDates: { speaker: 'bedouins', textKey: 'interactions.talk.bedouins.awaitingDates', duration: 6000 },
+      gratitude: { speaker: 'bedouins', textKey: 'interactions.talk.bedouins.gratitude', duration: 6500 },
+    },
+    action: ({ worldEvents }) => {
+      const hasWater = worldEvents.hasGivenWater();
+      const hasDates = worldEvents.hasReceivedDates();
+
+      if (hasWater && hasDates) {
+        return 'gratitude';
+      }
+
+      if (hasWater) {
+        return 'awaitingDates';
+      }
+
+      if (hasDates) {
+        return 'awaitingWaterWithDates';
+      }
+
+      return 'awaitingWater';
+    },
+  },
+  {
+    verb: 'talk',
+    target: 'camel',
+    conditions: [],
+    dialogues: {
+      curious: { speaker: 'camel', textKey: 'interactions.talk.camel.curious', duration: 5000 },
+      sensesWater: { speaker: 'camel', textKey: 'interactions.talk.camel.sensesWater', duration: 5000 },
+      hopeful: { speaker: 'camel', textKey: 'interactions.talk.camel.hopeful', duration: 5500 },
+    },
+    action: ({ inventory, worldEvents }) => {
+      if (worldEvents.hasGivenWater() && worldEvents.hasReceivedDates()) {
+        return 'hopeful';
+      }
+
+      if (inventory.has('bucket of water')) {
+        return 'sensesWater';
+      }
+
+      return 'curious';
+    },
+  },
+  {
     verb: 'shake',
     target: 'palm tree',
     conditions: [],
@@ -112,6 +162,7 @@ export const interactions = [
       if (selectedItem === 'dates') {
         inventory.remove('dates');
         inventory.clearSelection();
+        worldEvents.markDatesDelivered();
         if (worldEvents.hasGivenWater()) {
           return 'datesAfterWater';
         }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -36,6 +36,11 @@ let selectedVerb = null;
 const verbs = document.querySelectorAll('.verb');
 const labels = document.querySelectorAll('.label');
 
+const clearSelectedVerb = () => {
+  selectedVerb = null;
+  verbs.forEach((item) => item.classList.remove('active'));
+};
+
 const context = {
   inventory,
   ui: dialogueUI,
@@ -56,7 +61,10 @@ const handleInteraction = (verb, target) => {
   if (!verb) {
     return;
   }
-  runInteraction({ verb, target, context });
+  const wasHandled = runInteraction({ verb, target, context });
+  if (wasHandled) {
+    clearSelectedVerb();
+  }
 };
 
 const worldEvents = new WorldEvents({

--- a/src/scripts/texts.js
+++ b/src/scripts/texts.js
@@ -38,6 +38,19 @@ export const TEXTS = {
         water: 'Nice.',
       },
     },
+    talk: {
+      bedouins: {
+        awaitingWater: 'Traveler, our tea is delayed without fresh water.',
+        awaitingWaterWithDates: 'The dates look delicious, but we still need fresh water for the kettle.',
+        awaitingDates: 'Thank you for the water! Could you also shake down some dates?',
+        gratitude: 'With water and dates, the tea will be perfect. You have our thanks.',
+      },
+      camel: {
+        curious: 'The camel blinks slowly, clearly expecting something interesting to happen.',
+        sensesWater: 'The camel sniffs at the bucket of water eagerly.',
+        hopeful: 'Everyone is getting ready for tea. Maybe there will be a spare cup for me.',
+      },
+    },
   },
   objects: {
     dates: {

--- a/src/scripts/world-events.js
+++ b/src/scripts/world-events.js
@@ -12,11 +12,16 @@ export class WorldEvents {
     this.onInteraction = onInteraction;
     this.getSelectedVerb = getSelectedVerb;
     this.gaveWaterFirst = false;
+    this.receivedDates = false;
     this.datesElement = null;
   }
 
   hasGivenWater() {
     return this.gaveWaterFirst;
+  }
+
+  hasReceivedDates() {
+    return this.receivedDates;
   }
 
   hasDatesOnGround() {
@@ -25,6 +30,10 @@ export class WorldEvents {
 
   markWaterDelivered() {
     this.gaveWaterFirst = true;
+  }
+
+  markDatesDelivered() {
+    this.receivedDates = true;
   }
 
   shakePalmTree() {


### PR DESCRIPTION
## Summary
- remove the unused OPEN verb option from the menu
- add TALK interactions for the bedouins and the camel with context-aware dialogue
- reset the selected verb after a successful interaction and track delivered dates in world events

## Testing
- npm test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e64af105d0832badda1396c115c4eb