### PR TITLE
Add initial greeting dialogue and style bubbles by actor color

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -103,10 +103,43 @@ function initializeGame() {
     isThought: true,
     duration: 3000,
   });
-  dialogueUI.show({
-    speaker: 'me',
-    text: getText('me.initialObservation'),
-  });
+  setupInitialGreeting();
+}
+
+function setupInitialGreeting() {
+  const meElement = actorElements.me;
+  if (!meElement) {
+    return;
+  }
+
+  let greetingShown = false;
+
+  const showGreeting = () => {
+    if (greetingShown) {
+      return;
+    }
+    greetingShown = true;
+
+    dialogueUI.show({
+      speaker: 'me',
+      text: 'Hello !',
+      duration: 3000,
+    });
+
+    setTimeout(() => {
+      dialogueUI.show({
+        speaker: 'bedouins',
+        text: 'Hello stranger !',
+        duration: 3000,
+      });
+    }, 3000);
+  };
+
+  meElement.addEventListener('animationend', showGreeting, { once: true });
+
+  setTimeout(() => {
+    showGreeting();
+  }, 6500);
 }
 
 initializeGame();

--- a/src/scripts/ui.js
+++ b/src/scripts/ui.js
@@ -37,11 +37,13 @@ export class DialogueUI {
     dialogueElement.style.transform = 'translateX(-50%)';
   }
 
-  show({ speaker, text, isThought = false, duration = 3500 }) {
+  show({ speaker, text, isThought = false, duration = 3000 }) {
     const dialogueElement = this.dialogueElements[speaker];
     if (!dialogueElement) {
       return;
     }
+
+    this.applySpeakerStyles({ speaker, dialogueElement });
 
     dialogueElement.innerHTML = isThought ? `<span class="thought">{{${text}}}</span>` : text;
     dialogueElement.style.display = 'block';
@@ -71,5 +73,63 @@ export class DialogueUI {
       clearTimeout(this.hideTimers.get(speaker));
       this.hideTimers.delete(speaker);
     }
+  }
+
+  applySpeakerStyles({ speaker, dialogueElement }) {
+    const actorElement = this.actorElements[speaker];
+    if (!actorElement) {
+      return;
+    }
+
+    const computedStyles = window.getComputedStyle(actorElement);
+    const backgroundColor = computedStyles.backgroundColor;
+    const textColor = computedStyles.color;
+
+    const adjustedBackground = this.getColorWithOpacity(backgroundColor, 0.7);
+    if (adjustedBackground) {
+      dialogueElement.style.backgroundColor = adjustedBackground;
+    }
+
+    if (textColor) {
+      dialogueElement.style.color = textColor;
+    }
+  }
+
+  getColorWithOpacity(colorString, alpha) {
+    if (!colorString) {
+      return null;
+    }
+
+    if (colorString === 'transparent') {
+      return null;
+    }
+
+    const rgbaMatch = colorString.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([\d.]+))?\)/i);
+    if (rgbaMatch) {
+      const [, r, g, b, existingAlpha] = rgbaMatch;
+      if (existingAlpha !== undefined && Number.parseFloat(existingAlpha) === 0) {
+        return null;
+      }
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+
+    if (colorString.startsWith('#')) {
+      let hex = colorString.slice(1);
+      if (hex.length === 3) {
+        hex = hex
+          .split('')
+          .map((char) => char + char)
+          .join('');
+      }
+
+      if (hex.length === 6) {
+        const r = parseInt(hex.slice(0, 2), 16);
+        const g = parseInt(hex.slice(2, 4), 16);
+        const b = parseInt(hex.slice(4, 6), 16);
+        return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+      }
+    }
+
+    return null;
   }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -118,21 +118,8 @@ body {
   display: none;
   z-index: 10;
   border: none;
-}
-
-.dialogue-me {
-  background: rgba(0, 0, 0, 0.9);
-  color: white;
-}
-
-.dialogue-other {
-  background: rgba(244, 227, 194, 0.95);
-  color: #4a3a17;
-}
-
-.dialogue-camel {
-  background: rgba(255, 230, 180, 0.95);
-  color: #2a1b0a;
+  border-radius: 0;
+  background: rgba(255, 255, 255, 0.7);
 }
 
 .thought {


### PR DESCRIPTION
## Summary
- show a greeting from Me followed by a response from the Bedouin once the Me block finishes its opening animation
- ensure dialogue bubbles inherit their actor color with 70% opacity and keep text colors aligned with the source labels
- standardize dialogue bubble styling with a rectangular fallback background and shorter default display time

## Testing
- npm test *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e653b581d0832b93a5b8d382a205a4