### PR TITLE
Set fixed character block sizes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -20,11 +20,11 @@
 
     <div class="label" data-name="palm tree">palm tree</div>
     <div class="label" data-name="carpet">carpet</div>
-    <div class="label" data-name="bedouins">bedouins</div>
+    <div class="label label--character label--sitting" data-name="bedouins">bedouins</div>
     <div class="label" data-name="camel">camel</div>
     <div class="label" data-name="pond">pond</div>
     <div class="label" data-name="bucket">bucket</div>
-    <div class="label" data-name="me">ME</div>
+    <div class="label label--character label--standing" data-name="me">ME</div>
     <div class="dialogue-box dialogue-me" id="dialogue-me"></div>
     <div class="dialogue-box dialogue-other" id="dialogue-bedouins"></div>
     <div class="dialogue-box dialogue-camel" id="dialogue-camel"></div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -53,19 +53,32 @@ body {
   width: var(--size-width, max-content);
   height: var(--size-height, max-content);
   z-index: var(--layer, 2);
+  box-sizing: border-box;
+}
+
+.label--character {
+  width: 100px;
+  padding: 0;
+}
+
+.label--character.label--standing {
+  height: 170px;
+}
+
+.label--character.label--sitting {
+  height: 120px;
 }
 
 .label[data-name="me"] {
   font-weight: bold;
   background: black;
   color: white;
-  width: 40px;
-  height: 70px;
   top: 5%;
   left: 40%;
   animation: dashPath 6s ease-in-out forwards;
   z-index: 3;
   transform: scale(0.3);
+  transform-origin: center bottom;
 }
 
 .label[data-name="bedouins"] {
@@ -233,10 +246,6 @@ body {
 @media (max-width: 480px) {
   #game {
     aspect-ratio: 4 / 5;
-  }
-
-  .label[data-name="me"] {
-    left: 45%;
   }
 
   .verb {


### PR DESCRIPTION
## Summary
- add dedicated character sizing classes for standing and sitting blocks
- apply the new fixed dimensions to the ME and bedouins labels and adjust animation origin

## Testing
- npm test *(fails: tests/interactions.test.js > interactions table > gives dates to the bedouins before water)*

------
https://chatgpt.com/codex/tasks/task_e_68e65b74e400832bb3673d703f2d873b