### PR TITLE
Expand scene container to fill full page height

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3,17 +3,16 @@ body {
   font-family: 'Courier New', monospace;
   background: #c4b59a;
   overflow-x: hidden;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
   min-height: 100vh;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto auto;
+  justify-items: stretch;
 }
 
 #game {
   position: relative;
-  width: min(100vw, 1100px);
-  max-height: 80vh;
-  aspect-ratio: 16 / 9;
+  width: min(100%, 1100px);
+  height: 100%;
   background: #c4b59a;
   overflow: hidden;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- switch the page layout to a three-row grid so the scene row stretches to the footer actions
- let the scene container grow to the full available height while keeping it centered on wide displays

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e65d317b24832bb9b124071e7cd052