### PR TITLE
Fix Bedouins layout to use character sitting dimensions

### DIFF
--- a/src/scripts/layout.js
+++ b/src/scripts/layout.js
@@ -38,10 +38,6 @@ const sceneLayout = {
     },
     bedouins: {
       position: { default: { x: 0.32, y: 0.6 }, mobile: { x: 0.35, y: 0.62 } },
-      size: {
-        width: '352px',
-        height: '74px',
-      },
       fontScale: { default: 1.5, mobile: 1.35 },
       layer: 2,
     },


### PR DESCRIPTION
## Summary
- remove the explicit size overrides for the Bedouins label so it falls back to the sitting character dimensions

## Testing
- npm test *(fails: TypeError: worldEvents.markDatesDelivered is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68e66007fc6c832b97388ea90ea8103d