### PR TITLE
Refactor page layout to separate scene and menu

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -28,13 +28,15 @@
     <div class="dialogue-box dialogue-other" id="dialogue-bedouins"></div>
     <div class="dialogue-box dialogue-camel" id="dialogue-camel"></div>
   </div>
-  <div id="inventory">Inventory: <span id="inventory-items"></span></div>
-  <div id="verbs">
-    <div class="verb" data-verb="talk">TALK TO</div>
-    <div class="verb" data-verb="shake">SHAKE</div>
-    <div class="verb" data-verb="use">USE</div>
-    <div class="verb" data-verb="pickup">PICK UP</div>
-    <div class="verb" data-verb="give">GIVE</div>
+  <div id="menu">
+    <div id="inventory">Inventory: <span id="inventory-items"></span></div>
+    <div id="verbs">
+      <div class="verb" data-verb="talk">TALK TO</div>
+      <div class="verb" data-verb="shake">SHAKE</div>
+      <div class="verb" data-verb="use">USE</div>
+      <div class="verb" data-verb="pickup">PICK UP</div>
+      <div class="verb" data-verb="give">GIVE</div>
+    </div>
   </div>
   <script type="module" src="scripts/main.js"></script>
 </body>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -4,22 +4,30 @@ body {
   background: #c4b59a;
   overflow-x: hidden;
   min-height: 100vh;
-  display: grid;
-  grid-template-rows: minmax(0, 1fr) auto auto;
-  justify-items: stretch;
+  display: flex;
+  flex-direction: column;
 }
 
 #game {
   position: relative;
-  width: min(100%, 1100px);
+  flex: 1 1 auto;
+  width: 100%;
   height: 100%;
+  min-height: 0;
   background: #c4b59a;
   overflow: hidden;
-  margin: 0 auto;
+  margin: 0;
   --scene-width: 100%;
   --scene-height: 100%;
   --ambient-font-base: clamp(0.9rem, 1vw + 0.3rem, 1.4rem);
   --label-font-base: clamp(1rem, 1vw + 0.6rem, 2.4rem);
+}
+
+#menu {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  flex: 0 0 auto;
 }
 
 .ambient {
@@ -169,9 +177,10 @@ body {
   display: flex;
   align-items: center;
   gap: 0.5rem;
-  padding: 0.75rem 1rem;
+  padding: 0 1rem;
+  height: 50px;
+  flex: 0 0 50px;
   font-size: clamp(0.95rem, 0.6vw + 0.7rem, 1.15rem);
-  margin-top: auto;
 }
 
 #verbs {
@@ -179,7 +188,9 @@ body {
   justify-content: center;
   align-items: center;
   background: #f1e7d0;
-  padding: 0.75rem 1rem;
+  padding: 0 1rem;
+  height: 80px;
+  flex: 0 0 80px;
   gap: 0.75rem;
   font-size: clamp(1rem, 0.8vw + 0.6rem, 1.2rem);
 }


### PR DESCRIPTION
## Summary
- wrap the inventory and verbs controls in a full-width menu container
- convert the page layout to a flex column so the scene fills the remaining viewport area and the menu keeps fixed heights

## Testing
- `npm test` *(fails: TypeError: worldEvents.markDatesDelivered is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68e661c1f4b8832b9371fe9081e98ff1