### PR TITLE
Adjust carpet and camel positions

### DIFF
--- a/src/scripts/layout.js
+++ b/src/scripts/layout.js
@@ -25,7 +25,7 @@ const sceneLayout = {
       layer: 4,
     },
     carpet: {
-      position: { default: { x: 0.25, y: 0.45 } },
+      position: { default: { x: 0.18, y: 0.52 } },
       size: {
         width: '350px',
         height: '250px',
@@ -43,7 +43,7 @@ const sceneLayout = {
       layer: 2,
     },
     camel: {
-      position: { default: { x: 0.60, y: 0.42 } },
+      position: { default: { x: 0.63, y: 0.39 } },
       size: {
         width: '150px',
         height: '100px',


### PR DESCRIPTION
## Summary
- shift the carpet label further left and lower in the scene layout to sit nearer the palm tree without reaching the bottom edge
- nudge the camel label slightly upward and to the right for better spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6e444d15c832ba6e6439272ce4aaf