### PR TITLE
Add introductory text sequence with pause/resume control

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,11 @@
   <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>
-  <div id="game">
+  <div id="intro-sequence" class="intro-sequence">
+    <div class="intro-sequence__text" id="intro-text"></div>
+    <div class="intro-sequence__instructions" id="intro-instructions">Press space to pause</div>
+  </div>
+  <div id="game" class="is-hidden">
     <div class="ambient" data-ambient="dunes-west-1">dunes</div>
     <div class="ambient" data-ambient="dunes-west-2">more dunes</div>
     <div class="ambient" data-ambient="dunes-mid-1">dunes</div>
@@ -28,7 +32,7 @@
     <div class="dialogue-box dialogue-other" id="dialogue-bedouins"></div>
     <div class="dialogue-box dialogue-camel" id="dialogue-camel"></div>
   </div>
-  <div id="menu">
+  <div id="menu" class="is-hidden">
     <div id="inventory">Inventory: <span id="inventory-items"></span></div>
     <div id="verbs">
       <div class="verb" data-verb="talk">TALK TO</div>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -8,6 +8,42 @@ body {
   flex-direction: column;
 }
 
+.is-hidden {
+  display: none !important;
+}
+
+.intro-sequence {
+  position: fixed;
+  inset: 0;
+  background: #000;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem;
+  gap: 2rem;
+  z-index: 1000;
+}
+
+.intro-sequence__text {
+  font-size: clamp(1.5rem, 2vw + 1rem, 2.75rem);
+  line-height: 1.4;
+  max-width: min(800px, 90vw);
+}
+
+.intro-sequence__instructions {
+  position: absolute;
+  bottom: 2rem;
+  width: 100%;
+  text-align: center;
+  font-size: clamp(0.9rem, 1vw + 0.4rem, 1.3rem);
+  color: rgba(255, 255, 255, 0.75);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 #game {
   position: relative;
   flex: 1 1 auto;


### PR DESCRIPTION
## Summary
- add an introductory overlay that plays text sentences before the desert scene with pause/resume instructions
- defer rendering of the main scene until the sequence completes while keeping existing greetings intact

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e79033c434832b9af8c340445e651d