### PR TITLE
Add spacebar skip shortcut and transition screen

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -8,7 +8,7 @@
 <body>
   <div id="intro-sequence" class="intro-sequence">
     <div class="intro-sequence__text" id="intro-text"></div>
-    <div class="intro-sequence__instructions" id="intro-instructions">Press space to pause</div>
+    <div class="intro-sequence__instructions" id="intro-instructions">Press space to skip</div>
   </div>
   <div id="game" class="is-hidden">
     <div class="ambient" data-ambient="dunes-west-1">dunes</div>
@@ -40,6 +40,7 @@
       <div class="verb" data-verb="use">USE</div>
       <div class="verb" data-verb="pickup">PICK UP</div>
       <div class="verb" data-verb="give">GIVE</div>
+      <div class="verb-toolbar__hint" id="verb-skip-hint">press SPACE to skip</div>
     </div>
   </div>
   <script type="module" src="scripts/main.js"></script>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -238,6 +238,7 @@ body {
   flex: 0 0 80px;
   gap: 0.75rem;
   font-size: clamp(0.95rem, 0.7vw + 0.55rem, 1.1rem);
+  position: relative;
 }
 
 .verb {
@@ -253,6 +254,18 @@ body {
 .verb.active {
   background: black;
   color: white;
+}
+
+.verb-toolbar__hint {
+  position: absolute;
+  right: 1rem;
+  bottom: 0.5rem;
+  font-size: clamp(0.7rem, 0.45vw + 0.5rem, 0.9rem);
+  text-transform: uppercase;
+  color: #4c3f2a;
+  letter-spacing: 0.08em;
+  pointer-events: none;
+  white-space: nowrap;
 }
 
 .inventory-item {

--- a/tests/sequences.test.js
+++ b/tests/sequences.test.js
@@ -55,7 +55,7 @@ describe('playPauseableTextSequence', () => {
 
     expect(container.classList.contains('is-hidden')).toBe(false);
     expect(text.textContent).toBe('First');
-    expect(instructions.textContent).toBe('Press space to pause');
+    expect(instructions.textContent).toBe('Press space to skip');
     expect(game.classList.contains('is-hidden')).toBe(true);
     expect(menu.classList.contains('is-hidden')).toBe(true);
 
@@ -69,30 +69,32 @@ describe('playPauseableTextSequence', () => {
     expect(menu.classList.contains('is-hidden')).toBe(false);
   });
 
-  it('pauses and resumes when pressing space', () => {
+  it('skips the sequence when pressing space', () => {
     const { container, text, instructions, game, menu } = createElements();
+    const onComplete = vi.fn();
 
     playPauseableTextSequence({
       sentences: ['First', 'Second'],
       sentenceDuration: 1000,
+      onComplete,
+      hideGameOnStart: true,
+      showGameOnComplete: true,
+      hideMenuOnStart: true,
+      showMenuOnComplete: true,
       elements: { container, text, instructions, game, menu },
     });
 
-    vi.advanceTimersByTime(400);
+    expect(container.classList.contains('is-hidden')).toBe(false);
+    expect(text.textContent).toBe('First');
 
     const spaceEvent = new KeyboardEvent('keydown', { code: 'Space' });
     document.dispatchEvent(spaceEvent);
 
-    expect(instructions.textContent).toBe('Press space to resume');
-
-    vi.advanceTimersByTime(1000);
-    expect(text.textContent).toBe('First');
-
-    document.dispatchEvent(spaceEvent);
-    expect(instructions.textContent).toBe('Press space to pause');
-
-    vi.advanceTimersByTime(600);
-    expect(text.textContent).toBe('Second');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(container.classList.contains('is-hidden')).toBe(true);
+    expect(instructions.textContent).toBe('');
+    expect(game.classList.contains('is-hidden')).toBe(false);
+    expect(menu.classList.contains('is-hidden')).toBe(false);
   });
 
   it('immediately finalizes when no sentences provided', () => {


### PR DESCRIPTION
## Summary
- add a toolbar hint and intro message explaining the spacebar skip shortcut
- allow the spacebar to skip active sequences or jump straight to the post-desert transition with a 4 second "A moment later" screen
- update text sequence handling, styling, and tests to reflect the new skip behaviour

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68e7b86613fc832b86f58aeb73b0a40f