### PR TITLE
Restore desert layout alignment and clear tea scene

### DIFF
--- a/docs/scripts/scenes/tea.js
+++ b/docs/scripts/scenes/tea.js
@@ -1,9 +1,6 @@
 const teaScene = {
   name: 'tea',
-  ambients: [
-    { id: 'dusk-sky', text: 'dusk sky', position: { default: { x: 0.08, y: 0.08 } }, fontScale: 1.1 },
-    { id: 'desert-horizon', text: 'far dunes', position: { default: { x: 0.52, y: 0.12 } }, fontScale: 0.95 },
-  ],
+  ambients: [],
   labels: {},
 };
 

--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -81,6 +81,8 @@ body {
   font-size: calc(var(--ambient-font-base) * var(--font-scale, 1));
   top: calc(var(--pos-y, 0) * 100%);
   left: calc(var(--pos-x, 0) * 100%);
+  transform: translate(-50%, -50%);
+  transform-origin: center;
   padding: 0.25rem 0.4rem;
   box-sizing: border-box;
   overflow-wrap: anywhere;
@@ -103,6 +105,8 @@ body {
   font-size: calc(var(--label-font-base) * var(--font-scale, 1));
   top: calc(var(--pos-y, 0) * 100%);
   left: calc(var(--pos-x, 0) * 100%);
+  transform: translate(-50%, -50%);
+  transform-origin: center;
   width: var(--size-width, max-content);
   height: var(--size-height, max-content);
   z-index: var(--layer, 2);
@@ -133,7 +137,7 @@ body {
   left: 40%;
   animation: dashPath 6s ease-in-out forwards;
   z-index: 3;
-  transform: scale(0.3);
+  transform: translate(-50%, -50%) scale(0.3);
   transform-origin: center bottom;
 }
 
@@ -155,25 +159,25 @@ body {
   0% {
     left: 40%;
     top: 5%;
-    transform: scale(0.3);
+    transform: translate(-50%, -50%) scale(0.3);
   }
 
   25% {
     left: 48%;
     top: 20%;
-    transform: scale(0.4);
+    transform: translate(-50%, -50%) scale(0.4);
   }
 
   50% {
     left: 55%;
     top: 40%;
-    transform: scale(0.6);
+    transform: translate(-50%, -50%) scale(0.6);
   }
 
   100% {
     left: 62%;
     top: 56%;
-    transform: scale(0.8);
+    transform: translate(-50%, -50%) scale(0.8);
   }
 }
 

--- a/src/scripts/scenes/tea.js
+++ b/src/scripts/scenes/tea.js
@@ -1,9 +1,6 @@
 const teaScene = {
   name: 'tea',
-  ambients: [
-    { id: 'dusk-sky', text: 'dusk sky', position: { default: { x: 0.08, y: 0.08 } }, fontScale: 1.1 },
-    { id: 'desert-horizon', text: 'far dunes', position: { default: { x: 0.52, y: 0.12 } }, fontScale: 0.95 },
-  ],
+  ambients: [],
   labels: {},
 };
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -81,6 +81,8 @@ body {
   font-size: calc(var(--ambient-font-base) * var(--font-scale, 1));
   top: calc(var(--pos-y, 0) * 100%);
   left: calc(var(--pos-x, 0) * 100%);
+  transform: translate(-50%, -50%);
+  transform-origin: center;
   padding: 0.25rem 0.4rem;
   box-sizing: border-box;
   overflow-wrap: anywhere;
@@ -103,6 +105,8 @@ body {
   font-size: calc(var(--label-font-base) * var(--font-scale, 1));
   top: calc(var(--pos-y, 0) * 100%);
   left: calc(var(--pos-x, 0) * 100%);
+  transform: translate(-50%, -50%);
+  transform-origin: center;
   width: var(--size-width, max-content);
   height: var(--size-height, max-content);
   z-index: var(--layer, 2);
@@ -133,7 +137,7 @@ body {
   left: 40%;
   animation: dashPath 6s ease-in-out forwards;
   z-index: 3;
-  transform: scale(0.3);
+  transform: translate(-50%, -50%) scale(0.3);
   transform-origin: center bottom;
 }
 
@@ -155,25 +159,25 @@ body {
   0% {
     left: 40%;
     top: 5%;
-    transform: scale(0.3);
+    transform: translate(-50%, -50%) scale(0.3);
   }
 
   25% {
     left: 48%;
     top: 20%;
-    transform: scale(0.4);
+    transform: translate(-50%, -50%) scale(0.4);
   }
 
   50% {
     left: 55%;
     top: 40%;
-    transform: scale(0.6);
+    transform: translate(-50%, -50%) scale(0.6);
   }
 
   100% {
     left: 62%;
     top: 56%;
-    transform: scale(0.8);
+    transform: translate(-50%, -50%) scale(0.8);
   }
 }
 


### PR DESCRIPTION
## Summary
- center ambient and label elements so their configured coordinates match the original desert layout
- keep the player animation aligned with the new centering transform
- clear the tea scene configuration so the follow-up scene renders empty

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e830ba0f90832bac883b4d743f3a27