### PR TITLE
Lower desert scene elements and widen toolbar layout

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -6,6 +6,10 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  padding: clamp(0.75rem, 2vw, 1.75rem);
+  box-sizing: border-box;
 }
 
 .is-hidden {
@@ -46,30 +50,42 @@ body {
 
 #game {
   position: relative;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   width: 100%;
-  height: 100%;
+  max-width: 960px;
   min-height: 0;
   background: #c4b59a;
   overflow: hidden;
-  margin: 0;
+  margin: 0 auto;
+  padding: clamp(1.25rem, 2.5vw, 2.75rem) clamp(1rem, 2vw, 2rem) clamp(0.75rem, 1.5vw, 1.75rem);
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
   --scene-width: 100%;
   --scene-height: 100%;
   --ambient-font-base: clamp(0.9rem, 1vw + 0.3rem, 1.4rem);
   --label-font-base: clamp(0.85rem, 0.85vw + 0.4rem, 1.8rem);
+  --scene-offset-y: 0.12;
 }
 
 #scene-root {
   position: relative;
   width: 100%;
-  height: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  min-height: 0;
 }
 
 #menu {
   width: 100%;
+  max-width: 960px;
   display: flex;
   flex-direction: column;
   flex: 0 0 auto;
+  margin: 0 auto;
+  box-sizing: border-box;
+  gap: clamp(0.5rem, 1.5vw, 0.9rem);
 }
 
 .ambient {
@@ -79,7 +95,7 @@ body {
   opacity: 0.5;
   z-index: 0;
   font-size: calc(var(--ambient-font-base) * var(--font-scale, 1));
-  top: calc(var(--pos-y, 0) * 100%);
+  top: calc((var(--pos-y, 0) + var(--scene-offset-y, 0)) * 100%);
   left: calc(var(--pos-x, 0) * 100%);
   transform: translate(-50%, -50%);
   transform-origin: center;
@@ -105,7 +121,7 @@ body {
   color: black;
   transition: transform 0.2s;
   font-size: calc(var(--label-font-base) * var(--font-scale, 1));
-  top: calc(var(--pos-y, 0) * 100%);
+  top: calc((var(--pos-y, 0) + var(--scene-offset-y, 0)) * 100%);
   left: calc(var(--pos-x, 0) * 100%);
   transform: translate(-50%, -50%);
   transform-origin: center;
@@ -248,26 +264,26 @@ body {
 }
 
 #verbs {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  align-items: stretch;
   background: #f1e7d0;
-  padding: 0 1rem;
-  height: 80px;
-  flex: 0 0 80px;
-  gap: 0.75rem;
+  padding: clamp(0.5rem, 1vw, 0.75rem) clamp(0.75rem, 2vw, 1.5rem) clamp(0.75rem, 2vw, 1.5rem);
+  gap: clamp(0.5rem, 1.4vw, 0.85rem);
   font-size: clamp(0.95rem, 0.7vw + 0.55rem, 1.1rem);
   position: relative;
+  border-bottom: 2px solid #000;
 }
 
 .verb {
   margin: 0;
-  padding: 0.6rem 1.1rem;
+  padding: clamp(0.5rem, 0.8vw, 0.75rem) clamp(0.5rem, 1vw, 1rem);
   border: 1px solid black;
   background: white;
   cursor: pointer;
   box-sizing: border-box;
   overflow-wrap: anywhere;
+  text-align: center;
 }
 
 .verb.active {
@@ -277,8 +293,8 @@ body {
 
 .verb-toolbar__hint {
   position: absolute;
-  right: 1rem;
-  bottom: 0.5rem;
+  right: clamp(0.75rem, 2vw, 1.5rem);
+  bottom: clamp(0.4rem, 1vw, 0.75rem);
   font-size: clamp(0.7rem, 0.45vw + 0.5rem, 0.9rem);
   text-transform: uppercase;
   color: #4c3f2a;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6,6 +6,10 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1.5rem);
+  padding: clamp(0.75rem, 2vw, 1.75rem);
+  box-sizing: border-box;
 }
 
 .is-hidden {
@@ -46,30 +50,42 @@ body {
 
 #game {
   position: relative;
-  flex: 1 1 auto;
+  flex: 0 0 auto;
   width: 100%;
-  height: 100%;
+  max-width: 960px;
   min-height: 0;
   background: #c4b59a;
   overflow: hidden;
-  margin: 0;
+  margin: 0 auto;
+  padding: clamp(1.25rem, 2.5vw, 2.75rem) clamp(1rem, 2vw, 2rem) clamp(0.75rem, 1.5vw, 1.75rem);
+  box-sizing: border-box;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
   --scene-width: 100%;
   --scene-height: 100%;
   --ambient-font-base: clamp(0.9rem, 1vw + 0.3rem, 1.4rem);
   --label-font-base: clamp(0.85rem, 0.85vw + 0.4rem, 1.8rem);
+  --scene-offset-y: 0.12;
 }
 
 #scene-root {
   position: relative;
   width: 100%;
-  height: 100%;
+  aspect-ratio: 16 / 9;
+  height: auto;
+  min-height: 0;
 }
 
 #menu {
   width: 100%;
+  max-width: 960px;
   display: flex;
   flex-direction: column;
   flex: 0 0 auto;
+  margin: 0 auto;
+  box-sizing: border-box;
+  gap: clamp(0.5rem, 1.5vw, 0.9rem);
 }
 
 .ambient {
@@ -79,7 +95,7 @@ body {
   opacity: 0.5;
   z-index: 0;
   font-size: calc(var(--ambient-font-base) * var(--font-scale, 1));
-  top: calc(var(--pos-y, 0) * 100%);
+  top: calc((var(--pos-y, 0) + var(--scene-offset-y, 0)) * 100%);
   left: calc(var(--pos-x, 0) * 100%);
   transform: translate(-50%, -50%);
   transform-origin: center;
@@ -105,7 +121,7 @@ body {
   color: black;
   transition: transform 0.2s;
   font-size: calc(var(--label-font-base) * var(--font-scale, 1));
-  top: calc(var(--pos-y, 0) * 100%);
+  top: calc((var(--pos-y, 0) + var(--scene-offset-y, 0)) * 100%);
   left: calc(var(--pos-x, 0) * 100%);
   transform: translate(-50%, -50%);
   transform-origin: center;
@@ -248,26 +264,26 @@ body {
 }
 
 #verbs {
-  display: flex;
-  justify-content: center;
-  align-items: center;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  align-items: stretch;
   background: #f1e7d0;
-  padding: 0 1rem;
-  height: 80px;
-  flex: 0 0 80px;
-  gap: 0.75rem;
+  padding: clamp(0.5rem, 1vw, 0.75rem) clamp(0.75rem, 2vw, 1.5rem) clamp(0.75rem, 2vw, 1.5rem);
+  gap: clamp(0.5rem, 1.4vw, 0.85rem);
   font-size: clamp(0.95rem, 0.7vw + 0.55rem, 1.1rem);
   position: relative;
+  border-bottom: 2px solid #000;
 }
 
 .verb {
   margin: 0;
-  padding: 0.6rem 1.1rem;
+  padding: clamp(0.5rem, 0.8vw, 0.75rem) clamp(0.5rem, 1vw, 1rem);
   border: 1px solid black;
   background: white;
   cursor: pointer;
   box-sizing: border-box;
   overflow-wrap: anywhere;
+  text-align: center;
 }
 
 .verb.active {
@@ -277,8 +293,8 @@ body {
 
 .verb-toolbar__hint {
   position: absolute;
-  right: 1rem;
-  bottom: 0.5rem;
+  right: clamp(0.75rem, 2vw, 1.5rem);
+  bottom: clamp(0.4rem, 1vw, 0.75rem);
   font-size: clamp(0.7rem, 0.45vw + 0.5rem, 0.9rem);
   text-transform: uppercase;
   color: #4c3f2a;


### PR DESCRIPTION
## Summary
- shift the desert scene stacking to align the labels closer to the inventory by introducing a shared vertical offset
- stretch the game and menu containers to full width with responsive padding so the toolbar spans the viewport without overlaps
- mirror the layout adjustments in the docs build to keep the published site in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e8c81a72f4832b8bd058642d37a9b5