### PR TITLE
Adjust layout to span full width

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6,7 +6,7 @@ body {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: stretch;
   gap: clamp(0.75rem, 2vw, 1.5rem);
   padding: clamp(0.75rem, 2vw, 1.75rem);
   box-sizing: border-box;
@@ -52,11 +52,10 @@ body {
   position: relative;
   flex: 0 0 auto;
   width: 100%;
-  max-width: 960px;
   min-height: 0;
   background: #c4b59a;
   overflow: hidden;
-  margin: 0 auto;
+  margin: 0;
   padding: clamp(1.25rem, 2.5vw, 2.75rem) clamp(1rem, 2vw, 2rem) clamp(0.75rem, 1.5vw, 1.75rem);
   box-sizing: border-box;
   display: flex;
@@ -79,11 +78,10 @@ body {
 
 #menu {
   width: 100%;
-  max-width: 960px;
   display: flex;
   flex-direction: column;
   flex: 0 0 auto;
-  margin: 0 auto;
+  margin: 0;
   box-sizing: border-box;
   gap: clamp(0.5rem, 1.5vw, 0.9rem);
 }


### PR DESCRIPTION
## Summary
- allow the body flex container to stretch children so the app spans the full viewport width
- remove the max-width and centering from the game and menu sections to restore their original full-width placement

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e929816128832b8b9b2dab0c56ad82