### PR TITLE
Adjust menu layout to avoid scrolling

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -6,12 +6,12 @@ body {
   margin: 0;
   font-family: 'Courier New', monospace;
   background: #c4b59a;
-  overflow-x: hidden;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: minmax(0, 1fr) auto;
   align-items: stretch;
-  gap: clamp(0.75rem, 2vw, 1.5rem);
+  row-gap: clamp(0.75rem, 2vw, 1.5rem);
   padding: var(--app-gutter);
   box-sizing: border-box;
 }
@@ -266,19 +266,18 @@ body {
 }
 
 #verbs {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, max-content));
+  display: flex;
+  flex-wrap: nowrap;
   justify-content: center;
-  justify-items: center;
-  align-items: stretch;
+  align-items: center;
   background: #f1e7d0;
   padding: clamp(0.5rem, 1vw, 0.75rem) clamp(0.75rem, 2vw, 1.5rem) clamp(0.75rem, 2vw, 1.5rem);
   gap: clamp(0.5rem, 1.4vw, 0.85rem);
   font-size: clamp(0.95rem, 0.7vw + 0.55rem, 1.1rem);
   position: relative;
   border-bottom: 2px solid #000;
-  width: min(100%, 650px);
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
 }
 
 .verb {
@@ -290,6 +289,7 @@ body {
   box-sizing: border-box;
   overflow-wrap: anywhere;
   text-align: center;
+  white-space: nowrap;
 }
 
 .verb.active {


### PR DESCRIPTION
## Summary
- switch the page layout to a full-height grid so the scene and menu share the viewport without scrolling
- keep the verb toolbar full-width while centering its buttons on a single row with consistent spacing

## Testing
- not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68ea24af4a28832bb26d2fb86589c327