### PR TITLE
Add interactive scene builder and integrate with runtime

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -17,6 +17,10 @@
     <div class="dialogue-box dialogue-camel" id="dialogue-camel"></div>
   </div>
   <div id="menu" class="is-hidden">
+    <div class="menu-toolbar">
+      <label for="scene-selector" class="menu-toolbar__label">Scene</label>
+      <select id="scene-selector" class="menu-toolbar__select"></select>
+    </div>
     <div id="inventory">Inventory: <span id="inventory-items"></span></div>
     <div id="verbs">
       <div class="verb" data-verb="talk">TALK TO</div>
@@ -27,6 +31,7 @@
       <div class="verb-toolbar__hint" id="verb-skip-hint">press SPACE to skip</div>
     </div>
   </div>
-  <script type="module" src="scripts/main.js"></script>
+  <div id="builder-root" class="is-hidden"></div>
+  <script type="module" src="scripts/app.js"></script>
 </body>
 </html>

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -1,0 +1,10 @@
+const params = new URLSearchParams(window.location.search);
+const mode = params.get('mode');
+
+if (mode === 'builder') {
+  import('./builder/main.js');
+  document.body.dataset.mode = 'builder';
+} else {
+  import('./main.js');
+  document.body.dataset.mode = 'game';
+}

--- a/src/scripts/builder/main.js
+++ b/src/scripts/builder/main.js
@@ -1,0 +1,1465 @@
+import { DialogueUI } from '../ui.js';
+import { scenes as runtimeScenes } from '../scenes/index.js';
+import {
+  cloneBuilderState,
+  createInitialStateFromScenes,
+  loadBuilderState,
+  saveBuilderState,
+} from './storage.js';
+
+const CANVAS_WIDTH = 960;
+const CANVAS_HEIGHT = 540;
+const MIN_LABEL_SIZE = 24;
+
+const gameElement = document.getElementById('game');
+const menuElement = document.getElementById('menu');
+const introElement = document.getElementById('intro-sequence');
+const builderRoot = document.getElementById('builder-root');
+
+if (gameElement) {
+  gameElement.classList.add('is-hidden');
+}
+if (menuElement) {
+  menuElement.classList.add('is-hidden');
+}
+if (introElement) {
+  introElement.classList.add('is-hidden');
+}
+
+if (!builderRoot) {
+  throw new Error('Builder root element is missing');
+}
+
+builderRoot.classList.remove('is-hidden');
+
+function deepClone(value) {
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(value);
+    } catch (error) {
+      // ignore and fallback
+    }
+  }
+  return JSON.parse(JSON.stringify(value));
+}
+
+function sanitizeSceneName(value, fallback) {
+  if (!value) {
+    return fallback;
+  }
+  return value.toString().trim();
+}
+
+function sanitizeId(value, fallback) {
+  if (!value || typeof value !== 'string') {
+    return fallback;
+  }
+  const normalized = value.trim().replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-_]/g, '').toLowerCase();
+  return normalized || fallback;
+}
+
+function ensureSceneStructure(scene) {
+  if (!scene.data) {
+    scene.data = { name: scene.name, ambients: [], labels: {} };
+  }
+  if (!scene.data.ambients) {
+    scene.data.ambients = [];
+  }
+  if (!scene.data.labels) {
+    scene.data.labels = {};
+  }
+  if (!Array.isArray(scene.dialogues)) {
+    scene.dialogues = [];
+  }
+  if (!Array.isArray(scene.interactions)) {
+    scene.interactions = [];
+  }
+  return scene;
+}
+
+const storedState = loadBuilderState();
+const initialState = storedState && Array.isArray(storedState.scenes) && storedState.scenes.length
+  ? storedState
+  : createInitialStateFromScenes(runtimeScenes);
+
+initialState.scenes = (initialState.scenes || []).map((scene, index) => {
+  const ensured = ensureSceneStructure(scene);
+  if (!ensured.id) {
+    ensured.id = sanitizeId(ensured.name, `scene-${index + 1}`);
+  }
+  ensured.name = sanitizeSceneName(ensured.name, `scene-${index + 1}`);
+  ensured.data.name = ensured.name;
+  return ensured;
+});
+
+if (!initialState.scenes.length) {
+  initialState.scenes.push(
+    ensureSceneStructure({
+      id: 'scene-1',
+      name: 'scene-1',
+      data: { name: 'scene-1', ambients: [], labels: {} },
+      dialogues: [],
+      interactions: [],
+    }),
+  );
+}
+
+const builderState = initialState;
+let selectedSceneId = builderState.scenes[0]?.id || null;
+let selectedLabelName = null;
+let selectedDialogueId = null;
+let isDrawing = false;
+let drawStart = null;
+let dragState = null;
+let hasUnsavedChanges = false;
+
+const template = `
+  <div class="builder-app">
+    <aside class="builder-app__sidebar">
+      <header class="builder-sidebar__header">
+        <h1>Scene Builder</h1>
+        <button type="button" class="builder-button builder-button--primary" data-action="save">Save</button>
+        <div class="builder-status" data-status-message>Saved</div>
+      </header>
+      <div class="builder-section">
+        <div class="builder-section__header">
+          <h2>Scenes</h2>
+          <button type="button" class="builder-button" data-action="add-scene">Add Scene</button>
+        </div>
+        <ul class="builder-scene-list" data-scene-list></ul>
+      </div>
+    </aside>
+    <main class="builder-app__main">
+      <section class="builder-canvas-section">
+        <div class="builder-toolbar">
+          <div class="builder-toolbar__group">
+            <button type="button" class="builder-button" data-action="draw-label">Draw rectangle</button>
+            <button type="button" class="builder-button" data-action="add-label">Add component</button>
+          </div>
+          <div class="builder-toolbar__group">
+            <label class="builder-field">
+              <span class="builder-field__label">Scene title</span>
+              <input type="text" class="builder-input" data-scene-name />
+            </label>
+          </div>
+        </div>
+        <div class="builder-canvas-wrapper">
+          <div class="builder-canvas" data-canvas></div>
+        </div>
+      </section>
+      <section class="builder-panels">
+        <div class="builder-panel" data-panel="component">
+          <header class="builder-panel__header">
+            <h3>Component</h3>
+            <button type="button" class="builder-button builder-button--danger" data-action="delete-label">Delete</button>
+          </header>
+          <div class="builder-panel__body">
+            <form data-component-form class="builder-form">
+              <div class="builder-field">
+                <label class="builder-field__label">Name</label>
+                <input type="text" class="builder-input" name="name" />
+              </div>
+              <div class="builder-field">
+                <label class="builder-field__label">Label text</label>
+                <input type="text" class="builder-input" name="text" />
+              </div>
+              <div class="builder-field-group">
+                <div class="builder-field">
+                  <label class="builder-field__label">Position X</label>
+                  <input type="number" step="0.01" min="0" max="1" class="builder-input" name="posX" />
+                </div>
+                <div class="builder-field">
+                  <label class="builder-field__label">Position Y</label>
+                  <input type="number" step="0.01" min="0" max="1" class="builder-input" name="posY" />
+                </div>
+              </div>
+              <div class="builder-field-group">
+                <div class="builder-field">
+                  <label class="builder-field__label">Width (px)</label>
+                  <input type="number" min="${MIN_LABEL_SIZE}" class="builder-input" name="width" />
+                </div>
+                <div class="builder-field">
+                  <label class="builder-field__label">Height (px)</label>
+                  <input type="number" min="${MIN_LABEL_SIZE}" class="builder-input" name="height" />
+                </div>
+              </div>
+              <div class="builder-field-group">
+                <div class="builder-field">
+                  <label class="builder-field__label">Layer</label>
+                  <input type="number" class="builder-input" name="layer" />
+                </div>
+                <div class="builder-field">
+                  <label class="builder-field__label">Font scale</label>
+                  <input type="number" step="0.1" class="builder-input" name="fontScale" />
+                </div>
+              </div>
+              <div class="builder-field">
+                <label class="builder-field__label">Classes</label>
+                <input type="text" class="builder-input" name="classes" placeholder="comma separated" />
+              </div>
+            </form>
+          </div>
+        </div>
+        <div class="builder-panel" data-panel="dialogue">
+          <header class="builder-panel__header">
+            <h3>Dialogues</h3>
+            <button type="button" class="builder-button" data-action="add-dialogue">Add dialogue</button>
+          </header>
+          <div class="builder-panel__body">
+            <div class="builder-dialogue-layout">
+              <aside class="builder-dialogue-list" data-dialogue-list></aside>
+              <form class="builder-form builder-dialogue-form" data-dialogue-form>
+                <div class="builder-field-group">
+                  <div class="builder-field">
+                    <label class="builder-field__label">Identifier</label>
+                    <input type="text" class="builder-input" name="dialogueId" />
+                  </div>
+                  <div class="builder-field">
+                    <label class="builder-field__label">Speaker</label>
+                    <input type="text" class="builder-input" name="dialogueSpeaker" />
+                  </div>
+                </div>
+                <div class="builder-field-group">
+                  <div class="builder-field">
+                    <label class="builder-field__label">Anchor</label>
+                    <select class="builder-input" name="dialogueAnchor"></select>
+                  </div>
+                  <div class="builder-field">
+                    <label class="builder-field__label">Duration (ms)</label>
+                    <input type="number" min="0" class="builder-input" name="dialogueDuration" />
+                  </div>
+                </div>
+                <div class="builder-field builder-field--checkbox">
+                  <label>
+                    <input type="checkbox" name="dialogueThought" /> Thought bubble
+                  </label>
+                </div>
+                <div class="builder-field">
+                  <label class="builder-field__label">Dialogue text</label>
+                  <textarea class="builder-input builder-textarea" name="dialogueText"></textarea>
+                </div>
+                <div class="builder-dialogue-actions">
+                  <button type="button" class="builder-button" data-action="play-dialogue">Play</button>
+                  <button type="button" class="builder-button builder-button--danger" data-action="delete-dialogue">Delete</button>
+                </div>
+              </form>
+            </div>
+          </div>
+        </div>
+        <div class="builder-panel" data-panel="interactions">
+          <header class="builder-panel__header">
+            <h3>Interactions</h3>
+            <button type="button" class="builder-button" data-action="add-interaction">Add interaction</button>
+          </header>
+          <div class="builder-panel__body" data-interaction-list></div>
+        </div>
+      </section>
+    </main>
+  </div>
+`;
+
+builderRoot.innerHTML = template;
+builderRoot.innerHTML = template;
+
+const sceneListElement = builderRoot.querySelector('[data-scene-list]');
+const saveButton = builderRoot.querySelector('[data-action="save"]');
+const addSceneButton = builderRoot.querySelector('[data-action="add-scene"]');
+const sceneNameInput = builderRoot.querySelector('[data-scene-name]');
+const statusElement = builderRoot.querySelector('[data-status-message]');
+const canvasElement = builderRoot.querySelector('[data-canvas]');
+const drawButton = builderRoot.querySelector('[data-action="draw-label"]');
+const addLabelButton = builderRoot.querySelector('[data-action="add-label"]');
+const deleteLabelButton = builderRoot.querySelector('[data-action="delete-label"]');
+const componentForm = builderRoot.querySelector('[data-component-form]');
+const dialogueListElement = builderRoot.querySelector('[data-dialogue-list]');
+const dialogueForm = builderRoot.querySelector('[data-dialogue-form]');
+const addDialogueButton = builderRoot.querySelector('[data-action="add-dialogue"]');
+const playDialogueButton = builderRoot.querySelector('[data-action="play-dialogue"]');
+const deleteDialogueButton = builderRoot.querySelector('[data-action="delete-dialogue"]');
+const interactionListElement = builderRoot.querySelector('[data-interaction-list]');
+const addInteractionButton = builderRoot.querySelector('[data-action="add-interaction"]');
+
+canvasElement.style.width = `${CANVAS_WIDTH}px`;
+canvasElement.style.height = `${CANVAS_HEIGHT}px`;
+
+const previewLayer = document.createElement('div');
+previewLayer.className = 'builder-preview-layer';
+canvasElement.appendChild(previewLayer);
+
+const fallbackAnchor = document.createElement('div');
+fallbackAnchor.className = 'builder-preview-anchor';
+canvasElement.appendChild(fallbackAnchor);
+
+const dialogueElements = {};
+const actorElements = {};
+const dialogueUI = new DialogueUI({
+  dialogueElements,
+  actorElements,
+  gameElement: canvasElement,
+});
+
+const labelElementMap = new Map();
+
+function markDirty() {
+  hasUnsavedChanges = true;
+  if (statusElement) {
+    statusElement.textContent = 'Unsaved changes';
+  }
+}
+
+function markSaved() {
+  hasUnsavedChanges = false;
+  if (statusElement) {
+    const timestamp = new Date().toLocaleTimeString();
+    statusElement.textContent = `Saved ${timestamp}`;
+  }
+}
+
+function getSelectedScene() {
+  return builderState.scenes.find((scene) => scene.id === selectedSceneId) || null;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function ensurePosition(config) {
+  if (!config.position) {
+    config.position = { default: { x: 0.5, y: 0.5 } };
+  }
+  if (!config.position.default) {
+    config.position.default = { x: 0.5, y: 0.5 };
+  }
+  return config.position.default;
+}
+
+function ensureSize(config) {
+  if (!config.size) {
+    config.size = { width: `${MIN_LABEL_SIZE * 4}px`, height: `${MIN_LABEL_SIZE * 3}px` };
+  }
+  if (!config.size.width) {
+    config.size.width = `${MIN_LABEL_SIZE * 4}px`;
+  }
+  if (!config.size.height) {
+    config.size.height = `${MIN_LABEL_SIZE * 3}px`;
+  }
+  return config.size;
+}
+
+function getLabelConfig(name) {
+  const scene = getSelectedScene();
+  if (!scene) {
+    return null;
+  }
+  scene.data.labels = scene.data.labels || {};
+  return scene.data.labels[name] || null;
+}
+
+function updateLabelElementPosition(element, config) {
+  const position = ensurePosition(config);
+  const size = ensureSize(config);
+  const width = parseFloat(size.width) || MIN_LABEL_SIZE * 4;
+  const height = parseFloat(size.height) || MIN_LABEL_SIZE * 3;
+  element.style.width = `${Math.max(width, MIN_LABEL_SIZE)}px`;
+  element.style.height = `${Math.max(height, MIN_LABEL_SIZE)}px`;
+  element.style.left = `${clamp(position.x, 0, 1) * 100}%`;
+  element.style.top = `${clamp(position.y, 0, 1) * 100}%`;
+}
+
+function getAllLabelNames(scene) {
+  const labels = scene?.data?.labels || {};
+  return Object.keys(labels);
+}
+
+function generateUniqueLabelName(baseName = 'component') {
+  const scene = getSelectedScene();
+  if (!scene) {
+    return baseName;
+  }
+  const labels = getAllLabelNames(scene);
+  let counter = labels.length + 1;
+  let candidate = `${baseName}-${counter}`;
+  while (labels.includes(candidate)) {
+    counter += 1;
+    candidate = `${baseName}-${counter}`;
+  }
+  return candidate;
+}
+
+function renderSceneList() {
+  if (!sceneListElement) {
+    return;
+  }
+
+  sceneListElement.innerHTML = '';
+
+  builderState.scenes.forEach((scene, index) => {
+    const item = document.createElement('li');
+    item.className = 'builder-scene-list__item';
+    item.dataset.id = scene.id;
+
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `builder-scene-list__button${scene.id === selectedSceneId ? ' is-active' : ''}`;
+    button.textContent = scene.name;
+    button.addEventListener('click', () => {
+      selectedSceneId = scene.id;
+      selectedLabelName = null;
+      selectedDialogueId = null;
+      renderAll();
+    });
+    item.appendChild(button);
+
+    const controls = document.createElement('div');
+    controls.className = 'builder-scene-list__controls';
+
+    const upButton = document.createElement('button');
+    upButton.type = 'button';
+    upButton.className = 'builder-icon-button';
+    upButton.textContent = '▲';
+    upButton.title = 'Move up';
+    upButton.disabled = index === 0;
+    upButton.addEventListener('click', () => {
+      if (index === 0) {
+        return;
+      }
+      const [removed] = builderState.scenes.splice(index, 1);
+      builderState.scenes.splice(index - 1, 0, removed);
+      markDirty();
+      renderSceneList();
+    });
+    controls.appendChild(upButton);
+
+    const downButton = document.createElement('button');
+    downButton.type = 'button';
+    downButton.className = 'builder-icon-button';
+    downButton.textContent = '▼';
+    downButton.title = 'Move down';
+    downButton.disabled = index === builderState.scenes.length - 1;
+    downButton.addEventListener('click', () => {
+      if (index === builderState.scenes.length - 1) {
+        return;
+      }
+      const [removed] = builderState.scenes.splice(index, 1);
+      builderState.scenes.splice(index + 1, 0, removed);
+      markDirty();
+      renderSceneList();
+    });
+    controls.appendChild(downButton);
+
+    const duplicateButton = document.createElement('button');
+    duplicateButton.type = 'button';
+    duplicateButton.className = 'builder-icon-button';
+    duplicateButton.textContent = '⧉';
+    duplicateButton.title = 'Duplicate scene';
+    duplicateButton.addEventListener('click', () => {
+      const duplicate = deepClone(scene);
+      duplicate.id = `${scene.id}-copy-${Date.now()}`;
+      duplicate.name = `${scene.name} copy`;
+      duplicate.data.name = duplicate.name;
+      builderState.scenes.splice(index + 1, 0, ensureSceneStructure(duplicate));
+      selectedSceneId = duplicate.id;
+      selectedLabelName = null;
+      selectedDialogueId = null;
+      markDirty();
+      renderAll();
+    });
+    controls.appendChild(duplicateButton);
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.className = 'builder-icon-button builder-icon-button--danger';
+    deleteButton.textContent = '✕';
+    deleteButton.title = 'Delete scene';
+    deleteButton.disabled = builderState.scenes.length <= 1;
+    deleteButton.addEventListener('click', () => {
+      if (builderState.scenes.length <= 1) {
+        return;
+      }
+      builderState.scenes.splice(index, 1);
+      if (selectedSceneId === scene.id) {
+        selectedSceneId = builderState.scenes[0]?.id || null;
+        selectedLabelName = null;
+        selectedDialogueId = null;
+      }
+      markDirty();
+      renderAll();
+    });
+    controls.appendChild(deleteButton);
+
+    item.appendChild(controls);
+    sceneListElement.appendChild(item);
+  });
+}
+
+function selectLabel(name) {
+  selectedLabelName = name;
+  updateComponentPanel();
+  renderSceneCanvas();
+}
+
+function handleLabelPointerDown(event, name) {
+  event.stopPropagation();
+  selectLabel(name);
+
+  const labelConfig = getLabelConfig(name);
+  if (!labelConfig) {
+    return;
+  }
+
+  const position = ensurePosition(labelConfig);
+  const canvasRect = canvasElement.getBoundingClientRect();
+  const pointerX = (event.clientX - canvasRect.left) / canvasRect.width;
+  const pointerY = (event.clientY - canvasRect.top) / canvasRect.height;
+
+  dragState = {
+    mode: 'move',
+    name,
+    offsetX: pointerX - position.x,
+    offsetY: pointerY - position.y,
+  };
+
+  canvasElement.setPointerCapture(event.pointerId);
+}
+
+function handleResizePointerDown(event, name) {
+  event.stopPropagation();
+  selectLabel(name);
+
+  const labelConfig = getLabelConfig(name);
+  if (!labelConfig) {
+    return;
+  }
+
+  const size = ensureSize(labelConfig);
+  const startWidth = parseFloat(size.width) || MIN_LABEL_SIZE * 4;
+  const startHeight = parseFloat(size.height) || MIN_LABEL_SIZE * 3;
+
+  dragState = {
+    mode: 'resize',
+    name,
+    startWidth,
+    startHeight,
+    startX: event.clientX,
+    startY: event.clientY,
+  };
+
+  canvasElement.setPointerCapture(event.pointerId);
+}
+function updateComponentPanel() {
+  if (!componentForm) {
+    return;
+  }
+
+  const inputs = componentForm.querySelectorAll('.builder-input');
+  inputs.forEach((input) => {
+    if (input instanceof HTMLInputElement || input instanceof HTMLTextAreaElement) {
+      input.value = '';
+    }
+  });
+
+  const scene = getSelectedScene();
+  if (!scene || !selectedLabelName) {
+    componentForm.setAttribute('data-empty', 'true');
+    if (deleteLabelButton) {
+      deleteLabelButton.disabled = true;
+    }
+    return;
+  }
+
+  componentForm.removeAttribute('data-empty');
+  if (deleteLabelButton) {
+    deleteLabelButton.disabled = false;
+  }
+
+  const config = getLabelConfig(selectedLabelName);
+  if (!config) {
+    return;
+  }
+
+  const position = ensurePosition(config);
+  const size = ensureSize(config);
+
+  const nameField = componentForm.elements.namedItem('name');
+  if (nameField) {
+    nameField.value = selectedLabelName;
+  }
+
+  const textField = componentForm.elements.namedItem('text');
+  if (textField) {
+    textField.value = config.text || selectedLabelName;
+  }
+
+  const posXField = componentForm.elements.namedItem('posX');
+  if (posXField) {
+    posXField.value = Number(position.x || 0).toFixed(2);
+  }
+
+  const posYField = componentForm.elements.namedItem('posY');
+  if (posYField) {
+    posYField.value = Number(position.y || 0).toFixed(2);
+  }
+
+  const widthField = componentForm.elements.namedItem('width');
+  if (widthField) {
+    widthField.value = Math.round(parseFloat(size.width) || MIN_LABEL_SIZE * 4);
+  }
+
+  const heightField = componentForm.elements.namedItem('height');
+  if (heightField) {
+    heightField.value = Math.round(parseFloat(size.height) || MIN_LABEL_SIZE * 3);
+  }
+
+  const layerField = componentForm.elements.namedItem('layer');
+  if (layerField) {
+    layerField.value = config.layer != null ? Number(config.layer) : '';
+  }
+
+  const fontScaleField = componentForm.elements.namedItem('fontScale');
+  if (fontScaleField) {
+    const defaultScale = config.fontScale?.default ?? config.fontScale;
+    fontScaleField.value = defaultScale != null ? Number(defaultScale) : '';
+  }
+
+  const classesField = componentForm.elements.namedItem('classes');
+  if (classesField) {
+    classesField.value = Array.isArray(config.classes) ? config.classes.join(', ') : '';
+  }
+}
+
+function renderSceneCanvas() {
+  labelElementMap.clear();
+  const scene = getSelectedScene();
+  const hasLabels = scene && Object.keys(scene.data?.labels || {}).length > 0;
+  canvasElement.classList.toggle('is-empty', !hasLabels);
+
+  const existingLabels = canvasElement.querySelectorAll('.builder-label');
+  existingLabels.forEach((element) => {
+    if (element.parentElement === canvasElement) {
+      element.remove();
+    }
+  });
+
+  if (!scene) {
+    return;
+  }
+
+  const labels = scene.data.labels || {};
+  Object.keys(labels).forEach((name) => {
+    const config = labels[name];
+    const element = document.createElement('div');
+    element.className = `builder-label${selectedLabelName === name ? ' is-selected' : ''}`;
+    element.dataset.labelName = name;
+    element.textContent = config.text || name;
+    element.style.transform = 'translate(-50%, -50%)';
+    element.style.zIndex = config.layer != null ? `${config.layer}` : '2';
+
+    updateLabelElementPosition(element, config);
+
+    element.addEventListener('pointerdown', (event) => handleLabelPointerDown(event, name));
+
+    const handle = document.createElement('div');
+    handle.className = 'builder-label__handle';
+    handle.title = 'Resize';
+    handle.addEventListener('pointerdown', (event) => handleResizePointerDown(event, name));
+    element.appendChild(handle);
+
+    canvasElement.appendChild(element);
+    labelElementMap.set(name, element);
+  });
+}
+
+function updateSceneNameInput() {
+  if (!sceneNameInput) {
+    return;
+  }
+  const scene = getSelectedScene();
+  sceneNameInput.value = scene ? scene.name : '';
+}
+
+function updateDialogueList() {
+  if (!dialogueListElement) {
+    return;
+  }
+
+  dialogueListElement.innerHTML = '';
+
+  const scene = getSelectedScene();
+  const dialogues = scene ? scene.dialogues : [];
+
+  if (!dialogues || !dialogues.length) {
+    const empty = document.createElement('div');
+    empty.className = 'builder-empty-state';
+    empty.textContent = 'No dialogues yet';
+    dialogueListElement.appendChild(empty);
+    return;
+  }
+
+  dialogues.forEach((dialogue) => {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = `builder-dialogue-list__item${dialogue.id === selectedDialogueId ? ' is-active' : ''}`;
+    button.textContent = dialogue.id || '(unnamed)';
+    button.addEventListener('click', () => {
+      selectedDialogueId = dialogue.id;
+      updateDialogueForm();
+      updateDialogueList();
+    });
+    dialogueListElement.appendChild(button);
+  });
+}
+
+function updateDialogueForm() {
+  if (!dialogueForm) {
+    return;
+  }
+
+  const scene = getSelectedScene();
+  const dialogue = scene?.dialogues?.find((entry) => entry.id === selectedDialogueId) || null;
+
+  const formElements = {
+    id: dialogueForm.elements.namedItem('dialogueId'),
+    speaker: dialogueForm.elements.namedItem('dialogueSpeaker'),
+    anchor: dialogueForm.elements.namedItem('dialogueAnchor'),
+    duration: dialogueForm.elements.namedItem('dialogueDuration'),
+    text: dialogueForm.elements.namedItem('dialogueText'),
+    thought: dialogueForm.elements.namedItem('dialogueThought'),
+  };
+
+  const labelNames = getAllLabelNames(scene);
+
+  if (formElements.anchor) {
+    formElements.anchor.innerHTML = '';
+    const noneOption = document.createElement('option');
+    noneOption.value = '';
+    noneOption.textContent = 'None';
+    formElements.anchor.appendChild(noneOption);
+
+    labelNames.forEach((name) => {
+      const option = document.createElement('option');
+      option.value = name;
+      option.textContent = name;
+      formElements.anchor.appendChild(option);
+    });
+  }
+
+  if (!dialogue) {
+    dialogueForm.setAttribute('data-empty', 'true');
+    if (formElements.id) formElements.id.value = '';
+    if (formElements.speaker) formElements.speaker.value = '';
+    if (formElements.anchor) formElements.anchor.value = '';
+    if (formElements.duration) formElements.duration.value = '';
+    if (formElements.text) formElements.text.value = '';
+    if (formElements.thought) formElements.thought.checked = false;
+    if (playDialogueButton) playDialogueButton.disabled = true;
+    if (deleteDialogueButton) deleteDialogueButton.disabled = true;
+    return;
+  }
+
+  dialogueForm.removeAttribute('data-empty');
+  if (formElements.id) formElements.id.value = dialogue.id || '';
+  if (formElements.speaker) formElements.speaker.value = dialogue.speaker || '';
+  if (formElements.anchor) formElements.anchor.value = dialogue.anchor || '';
+  if (formElements.duration) {
+    formElements.duration.value = dialogue.duration != null ? Number(dialogue.duration) : '';
+  }
+  if (formElements.text) formElements.text.value = dialogue.text || '';
+  if (formElements.thought) formElements.thought.checked = Boolean(dialogue.isThought);
+  if (playDialogueButton) playDialogueButton.disabled = false;
+  if (deleteDialogueButton) deleteDialogueButton.disabled = false;
+}
+
+function renderInteractionList() {
+  if (!interactionListElement) {
+    return;
+  }
+
+  interactionListElement.innerHTML = '';
+
+  const scene = getSelectedScene();
+  const interactions = scene ? scene.interactions : [];
+
+  if (!interactions || !interactions.length) {
+    const empty = document.createElement('div');
+    empty.className = 'builder-empty-state';
+    empty.textContent = 'No interactions configured';
+    interactionListElement.appendChild(empty);
+    return;
+  }
+
+  const labelNames = getAllLabelNames(scene);
+  const dialogues = scene.dialogues || [];
+
+  interactions.forEach((interaction, index) => {
+    const row = document.createElement('div');
+    row.className = 'builder-interaction-row';
+
+    const verbField = document.createElement('input');
+    verbField.type = 'text';
+    verbField.className = 'builder-input builder-input--compact';
+    verbField.value = interaction.verb || '';
+    verbField.placeholder = 'Verb';
+    verbField.addEventListener('input', () => {
+      interaction.verb = verbField.value.trim();
+      markDirty();
+    });
+    row.appendChild(verbField);
+
+    const targetSelect = document.createElement('select');
+    targetSelect.className = 'builder-input builder-input--compact';
+    const defaultOption = document.createElement('option');
+    defaultOption.value = '';
+    defaultOption.textContent = 'Target';
+    targetSelect.appendChild(defaultOption);
+    labelNames.forEach((name) => {
+      const option = document.createElement('option');
+      option.value = name;
+      option.textContent = name;
+      targetSelect.appendChild(option);
+    });
+    targetSelect.value = interaction.target || '';
+    targetSelect.addEventListener('change', () => {
+      interaction.target = targetSelect.value;
+      markDirty();
+    });
+    row.appendChild(targetSelect);
+
+    const dialogueSelect = document.createElement('select');
+    dialogueSelect.className = 'builder-input builder-input--compact';
+    const noDialogueOption = document.createElement('option');
+    noDialogueOption.value = '';
+    noDialogueOption.textContent = 'Dialogue';
+    dialogueSelect.appendChild(noDialogueOption);
+    dialogues.forEach((dialogue) => {
+      const option = document.createElement('option');
+      option.value = dialogue.id || '';
+      option.textContent = dialogue.id || '(unnamed)';
+      dialogueSelect.appendChild(option);
+    });
+    dialogueSelect.value = interaction.dialogueId || '';
+    dialogueSelect.addEventListener('change', () => {
+      interaction.dialogueId = dialogueSelect.value;
+      markDirty();
+    });
+    row.appendChild(dialogueSelect);
+
+    const deleteButton = document.createElement('button');
+    deleteButton.type = 'button';
+    deleteButton.className = 'builder-icon-button builder-icon-button--danger';
+    deleteButton.textContent = '✕';
+    deleteButton.title = 'Delete interaction';
+    deleteButton.addEventListener('click', () => {
+      interactions.splice(index, 1);
+      markDirty();
+      renderInteractionList();
+    });
+    row.appendChild(deleteButton);
+
+    interactionListElement.appendChild(row);
+  });
+}
+
+function renderAll() {
+  renderSceneList();
+  renderSceneCanvas();
+  updateComponentPanel();
+  updateSceneNameInput();
+  updateDialogueList();
+  updateDialogueForm();
+  renderInteractionList();
+}
+function handleCanvasPointerMove(event) {
+  if (!dragState && !isDrawing) {
+    return;
+  }
+
+  const canvasRect = canvasElement.getBoundingClientRect();
+  const pointerX = clamp((event.clientX - canvasRect.left) / canvasRect.width, 0, 1);
+  const pointerY = clamp((event.clientY - canvasRect.top) / canvasRect.height, 0, 1);
+
+  if (dragState && dragState.mode === 'move') {
+    const labelConfig = getLabelConfig(dragState.name);
+    if (!labelConfig) {
+      return;
+    }
+    const position = ensurePosition(labelConfig);
+    position.x = clamp(pointerX - dragState.offsetX, 0, 1);
+    position.y = clamp(pointerY - dragState.offsetY, 0, 1);
+    const element = labelElementMap.get(dragState.name);
+    if (element) {
+      updateLabelElementPosition(element, labelConfig);
+    }
+    updateComponentPanel();
+    markDirty();
+    return;
+  }
+
+  if (dragState && dragState.mode === 'resize') {
+    const labelConfig = getLabelConfig(dragState.name);
+    if (!labelConfig) {
+      return;
+    }
+    const size = ensureSize(labelConfig);
+    const deltaX = event.clientX - dragState.startX;
+    const deltaY = event.clientY - dragState.startY;
+    size.width = `${Math.max(MIN_LABEL_SIZE, dragState.startWidth + deltaX)}px`;
+    size.height = `${Math.max(MIN_LABEL_SIZE, dragState.startHeight + deltaY)}px`;
+    const element = labelElementMap.get(dragState.name);
+    if (element) {
+      updateLabelElementPosition(element, labelConfig);
+    }
+    updateComponentPanel();
+    markDirty();
+    return;
+  }
+
+  if (isDrawing && drawStart && selectedLabelName) {
+    const labelConfig = getLabelConfig(selectedLabelName);
+    if (!labelConfig) {
+      return;
+    }
+    const position = ensurePosition(labelConfig);
+    const size = ensureSize(labelConfig);
+
+    const minX = Math.min(drawStart.x, pointerX);
+    const maxX = Math.max(drawStart.x, pointerX);
+    const minY = Math.min(drawStart.y, pointerY);
+    const maxY = Math.max(drawStart.y, pointerY);
+
+    position.x = clamp((minX + maxX) / 2, 0, 1);
+    position.y = clamp((minY + maxY) / 2, 0, 1);
+
+    const widthPx = Math.max((maxX - minX) * CANVAS_WIDTH, MIN_LABEL_SIZE);
+    const heightPx = Math.max((maxY - minY) * CANVAS_HEIGHT, MIN_LABEL_SIZE);
+    size.width = `${Math.round(widthPx)}px`;
+    size.height = `${Math.round(heightPx)}px`;
+
+    const element = labelElementMap.get(selectedLabelName);
+    if (element) {
+      updateLabelElementPosition(element, labelConfig);
+    }
+    updateComponentPanel();
+  }
+}
+
+function handleCanvasPointerUp(event) {
+  if (dragState) {
+    canvasElement.releasePointerCapture(event.pointerId);
+    dragState = null;
+    return;
+  }
+
+  if (isDrawing) {
+    canvasElement.releasePointerCapture(event.pointerId);
+    isDrawing = false;
+    drawStart = null;
+    if (drawButton) {
+      drawButton.classList.remove('is-active');
+    }
+    markDirty();
+    renderSceneCanvas();
+    updateComponentPanel();
+  }
+}
+
+function startDrawingLabel(pointerX, pointerY) {
+  const scene = getSelectedScene();
+  if (!scene) {
+    return;
+  }
+  const name = generateUniqueLabelName('component');
+  const config = {
+    text: name,
+    position: { default: { x: pointerX, y: pointerY } },
+    size: { width: `${MIN_LABEL_SIZE * 4}px`, height: `${MIN_LABEL_SIZE * 3}px` },
+    layer: 2,
+  };
+  scene.data.labels[name] = config;
+  selectedLabelName = name;
+  isDrawing = true;
+  drawStart = { x: pointerX, y: pointerY };
+  renderSceneCanvas();
+  updateComponentPanel();
+}
+
+canvasElement.addEventListener('pointermove', handleCanvasPointerMove);
+canvasElement.addEventListener('pointerup', handleCanvasPointerUp);
+canvasElement.addEventListener('pointerleave', () => {
+  dragState = null;
+  if (isDrawing) {
+    isDrawing = false;
+    drawStart = null;
+    if (drawButton) {
+      drawButton.classList.remove('is-active');
+    }
+    renderSceneCanvas();
+  }
+});
+
+canvasElement.addEventListener('pointerdown', (event) => {
+  const labelElement = event.target.closest('.builder-label');
+  if (labelElement) {
+    return;
+  }
+
+  const canvasRect = canvasElement.getBoundingClientRect();
+  const pointerX = clamp((event.clientX - canvasRect.left) / canvasRect.width, 0, 1);
+  const pointerY = clamp((event.clientY - canvasRect.top) / canvasRect.height, 0, 1);
+
+  if (isDrawing) {
+    startDrawingLabel(pointerX, pointerY);
+    canvasElement.setPointerCapture(event.pointerId);
+    return;
+  }
+
+  selectLabel(null);
+});
+
+if (drawButton) {
+  drawButton.addEventListener('click', () => {
+    if (isDrawing) {
+      isDrawing = false;
+      drawStart = null;
+      drawButton.classList.remove('is-active');
+      return;
+    }
+    isDrawing = true;
+    drawStart = null;
+    drawButton.classList.add('is-active');
+  });
+}
+
+if (addLabelButton) {
+  addLabelButton.addEventListener('click', () => {
+    const centerX = 0.5;
+    const centerY = 0.5;
+    startDrawingLabel(centerX, centerY);
+    isDrawing = false;
+    drawStart = null;
+    if (drawButton) {
+      drawButton.classList.remove('is-active');
+    }
+    markDirty();
+    renderSceneCanvas();
+    updateComponentPanel();
+  });
+}
+
+if (deleteLabelButton) {
+  deleteLabelButton.addEventListener('click', () => {
+    const scene = getSelectedScene();
+    if (!scene || !selectedLabelName) {
+      return;
+    }
+    if (scene.data.labels && scene.data.labels[selectedLabelName]) {
+      delete scene.data.labels[selectedLabelName];
+      scene.interactions = (scene.interactions || []).filter(
+        (interaction) => interaction.target !== selectedLabelName,
+      );
+      if (scene.dialogues) {
+        scene.dialogues.forEach((dialogue) => {
+          if (dialogue.anchor === selectedLabelName) {
+            dialogue.anchor = '';
+          }
+        });
+      }
+      selectedLabelName = null;
+      markDirty();
+      renderAll();
+    }
+  });
+}
+if (addSceneButton) {
+  addSceneButton.addEventListener('click', () => {
+    const baseName = `scene-${builderState.scenes.length + 1}`;
+    const id = `${sanitizeId(baseName, baseName)}-${Date.now()}`;
+    const newScene = ensureSceneStructure({
+      id,
+      name: baseName,
+      data: { name: baseName, ambients: [], labels: {} },
+      dialogues: [],
+      interactions: [],
+    });
+    builderState.scenes.push(newScene);
+    selectedSceneId = newScene.id;
+    selectedLabelName = null;
+    selectedDialogueId = null;
+    markDirty();
+    renderAll();
+  });
+}
+
+if (sceneNameInput) {
+  sceneNameInput.addEventListener('change', () => {
+    const scene = getSelectedScene();
+    if (!scene) {
+      return;
+    }
+    const nextName = sanitizeSceneName(sceneNameInput.value, scene.name);
+    if (!nextName || nextName === scene.name) {
+      sceneNameInput.value = scene.name;
+      return;
+    }
+    const duplicate = builderState.scenes.find((item) => item !== scene && item.name === nextName);
+    if (duplicate) {
+      sceneNameInput.value = scene.name;
+      return;
+    }
+    scene.name = nextName;
+    scene.data.name = nextName;
+    markDirty();
+    renderSceneList();
+  });
+}
+
+if (componentForm) {
+  componentForm.addEventListener('input', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement)) {
+      return;
+    }
+    const scene = getSelectedScene();
+    if (!scene || !selectedLabelName) {
+      return;
+    }
+    const config = getLabelConfig(selectedLabelName);
+    if (!config) {
+      return;
+    }
+
+    const field = target.name;
+    const value = target.value;
+
+    if (field === 'name') {
+      const nextName = sanitizeSceneName(value, selectedLabelName);
+      if (!nextName || nextName === selectedLabelName) {
+        target.value = selectedLabelName;
+        return;
+      }
+      if (scene.data.labels[nextName]) {
+        target.value = selectedLabelName;
+        return;
+      }
+      scene.data.labels[nextName] = config;
+      delete scene.data.labels[selectedLabelName];
+      scene.interactions.forEach((interaction) => {
+        if (interaction.target === selectedLabelName) {
+          interaction.target = nextName;
+        }
+      });
+      if (scene.dialogues) {
+        scene.dialogues.forEach((dialogue) => {
+          if (dialogue.anchor === selectedLabelName) {
+            dialogue.anchor = nextName;
+          }
+        });
+      }
+      selectedLabelName = nextName;
+      markDirty();
+      renderAll();
+      return;
+    }
+
+    if (field === 'text') {
+      config.text = value;
+      const element = labelElementMap.get(selectedLabelName);
+      if (element) {
+        element.textContent = value || selectedLabelName;
+      }
+      markDirty();
+      return;
+    }
+
+    if (field === 'posX' || field === 'posY') {
+      const numberValue = Number.parseFloat(value);
+      if (Number.isNaN(numberValue)) {
+        return;
+      }
+      const position = ensurePosition(config);
+      if (field === 'posX') {
+        position.x = clamp(numberValue, 0, 1);
+      } else {
+        position.y = clamp(numberValue, 0, 1);
+      }
+      const element = labelElementMap.get(selectedLabelName);
+      if (element) {
+        updateLabelElementPosition(element, config);
+      }
+      markDirty();
+      return;
+    }
+
+    if (field === 'width' || field === 'height') {
+      const numericValue = Number.parseFloat(value);
+      if (Number.isNaN(numericValue)) {
+        return;
+      }
+      const size = ensureSize(config);
+      const px = `${Math.max(MIN_LABEL_SIZE, Math.round(numericValue))}px`;
+      if (field === 'width') {
+        size.width = px;
+      } else {
+        size.height = px;
+      }
+      const element = labelElementMap.get(selectedLabelName);
+      if (element) {
+        updateLabelElementPosition(element, config);
+      }
+      markDirty();
+      return;
+    }
+
+    if (field === 'layer') {
+      const layerValue = value.trim() === '' ? null : Number.parseInt(value, 10);
+      config.layer = Number.isNaN(layerValue) ? null : layerValue;
+      renderSceneCanvas();
+      markDirty();
+      return;
+    }
+
+    if (field === 'fontScale') {
+      const scaleValue = value.trim() === '' ? null : Number.parseFloat(value);
+      if (scaleValue == null || Number.isNaN(scaleValue)) {
+        delete config.fontScale;
+      } else {
+        config.fontScale = { default: scaleValue };
+      }
+      markDirty();
+      return;
+    }
+
+    if (field === 'classes') {
+      const classes = value
+        .split(',')
+        .map((entry) => entry.trim())
+        .filter(Boolean);
+      config.classes = classes.length ? classes : undefined;
+      markDirty();
+    }
+  });
+}
+
+function generateDialogueId(scene, base = 'dialogue') {
+  const ids = new Set((scene.dialogues || []).map((dialogue) => dialogue.id));
+  let index = ids.size + 1;
+  let candidate = sanitizeId(`${base}-${index}`, `${base}-${index}`);
+  while (ids.has(candidate)) {
+    index += 1;
+    candidate = sanitizeId(`${base}-${index}`, `${base}-${index}`);
+  }
+  return candidate;
+}
+
+if (addDialogueButton) {
+  addDialogueButton.addEventListener('click', () => {
+    const scene = getSelectedScene();
+    if (!scene) {
+      return;
+    }
+    const dialogueId = generateDialogueId(scene);
+    const dialogue = {
+      id: dialogueId,
+      speaker: 'me',
+      text: '',
+      duration: 3000,
+      anchor: '',
+      isThought: false,
+    };
+    scene.dialogues = scene.dialogues || [];
+    scene.dialogues.push(dialogue);
+    selectedDialogueId = dialogueId;
+    markDirty();
+    updateDialogueList();
+    updateDialogueForm();
+    renderInteractionList();
+  });
+}
+
+if (dialogueForm) {
+  dialogueForm.addEventListener('input', (event) => {
+    const target = event.target;
+    if (!(target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement)) {
+      return;
+    }
+
+    const scene = getSelectedScene();
+    if (!scene || !selectedDialogueId) {
+      return;
+    }
+
+    const dialogue = scene.dialogues?.find((item) => item.id === selectedDialogueId);
+    if (!dialogue) {
+      return;
+    }
+
+    const field = target.name;
+    const value = target.type === 'checkbox' ? target.checked : target.value;
+
+    if (field === 'dialogueId') {
+      const nextIdRaw = String(value || '').trim();
+      if (!nextIdRaw) {
+        target.value = dialogue.id;
+        return;
+      }
+      const nextId = sanitizeId(nextIdRaw, dialogue.id);
+      if (nextId === dialogue.id) {
+        return;
+      }
+      if (scene.dialogues.some((item) => item !== dialogue && item.id === nextId)) {
+        target.value = dialogue.id;
+        return;
+      }
+      const previousId = dialogue.id;
+      dialogue.id = nextId;
+      scene.interactions.forEach((interaction) => {
+        if (interaction.dialogueId === previousId) {
+          interaction.dialogueId = nextId;
+        }
+      });
+      selectedDialogueId = nextId;
+      markDirty();
+      updateDialogueList();
+      renderInteractionList();
+      return;
+    }
+
+    if (field === 'dialogueSpeaker') {
+      dialogue.speaker = String(value || '').trim();
+      markDirty();
+      return;
+    }
+
+    if (field === 'dialogueAnchor') {
+      dialogue.anchor = value || '';
+      markDirty();
+      return;
+    }
+
+    if (field === 'dialogueDuration') {
+      const durationValue = value === '' ? null : Number.parseInt(value, 10);
+      dialogue.duration = Number.isNaN(durationValue) ? undefined : durationValue;
+      markDirty();
+      return;
+    }
+
+    if (field === 'dialogueText') {
+      dialogue.text = String(value || '');
+      markDirty();
+      return;
+    }
+
+    if (field === 'dialogueThought') {
+      dialogue.isThought = Boolean(value);
+      markDirty();
+    }
+  });
+}
+
+function ensureDialogueElementForSpeaker(speaker) {
+  if (!speaker) {
+    return null;
+  }
+  if (dialogueElements[speaker]) {
+    return dialogueElements[speaker];
+  }
+  const element = document.createElement('div');
+  element.className = 'dialogue-box dialogue-box--builder';
+  element.dataset.speaker = speaker;
+  element.style.display = 'none';
+  previewLayer.appendChild(element);
+  dialogueElements[speaker] = element;
+  return element;
+}
+
+function resolveAnchorElement(anchorName) {
+  if (anchorName && labelElementMap.has(anchorName)) {
+    return labelElementMap.get(anchorName);
+  }
+  return fallbackAnchor;
+}
+
+function playDialoguePreview(dialogue) {
+  if (!dialogue) {
+    return;
+  }
+  const speaker = dialogue.speaker || 'narrator';
+  const anchor = resolveAnchorElement(dialogue.anchor);
+  ensureDialogueElementForSpeaker(speaker);
+  actorElements[speaker] = anchor;
+  dialogueUI.show({
+    speaker,
+    text: dialogue.text || '',
+    duration: dialogue.duration != null ? dialogue.duration : 3000,
+    isThought: Boolean(dialogue.isThought),
+  });
+}
+
+if (playDialogueButton) {
+  playDialogueButton.addEventListener('click', () => {
+    const scene = getSelectedScene();
+    const dialogue = scene?.dialogues?.find((item) => item.id === selectedDialogueId);
+    playDialoguePreview(dialogue);
+  });
+}
+
+if (deleteDialogueButton) {
+  deleteDialogueButton.addEventListener('click', () => {
+    const scene = getSelectedScene();
+    if (!scene || !selectedDialogueId) {
+      return;
+    }
+    scene.dialogues = (scene.dialogues || []).filter((dialogue) => dialogue.id !== selectedDialogueId);
+    scene.interactions.forEach((interaction) => {
+      if (interaction.dialogueId === selectedDialogueId) {
+        interaction.dialogueId = '';
+      }
+    });
+    selectedDialogueId = scene.dialogues[0]?.id || null;
+    markDirty();
+    updateDialogueList();
+    updateDialogueForm();
+    renderInteractionList();
+  });
+}
+
+if (addInteractionButton) {
+  addInteractionButton.addEventListener('click', () => {
+    const scene = getSelectedScene();
+    if (!scene) {
+      return;
+    }
+    scene.interactions = scene.interactions || [];
+    scene.interactions.push({
+      id: `interaction-${Date.now()}`,
+      verb: 'talk',
+      target: '',
+      dialogueId: selectedDialogueId || '',
+    });
+    markDirty();
+    renderInteractionList();
+  });
+}
+
+if (saveButton) {
+  saveButton.addEventListener('click', () => {
+    const snapshot = cloneBuilderState(builderState);
+    const success = saveBuilderState(snapshot);
+    if (success) {
+      markSaved();
+    } else if (statusElement) {
+      statusElement.textContent = 'Failed to save';
+    }
+  });
+}
+
+window.addEventListener('beforeunload', (event) => {
+  if (!hasUnsavedChanges) {
+    return;
+  }
+  event.preventDefault();
+  // eslint-disable-next-line no-param-reassign
+  event.returnValue = '';
+});
+
+renderAll();
+markSaved();

--- a/src/scripts/builder/runtime.js
+++ b/src/scripts/builder/runtime.js
@@ -1,0 +1,158 @@
+import { loadBuilderState } from './storage.js';
+
+function deepClone(value) {
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(value);
+    } catch (error) {
+      // Fallback to JSON approach
+    }
+  }
+
+  return JSON.parse(JSON.stringify(value));
+}
+
+function setNestedValue(target, path, value) {
+  if (!path.length) {
+    return;
+  }
+
+  let current = target;
+  for (let index = 0; index < path.length; index += 1) {
+    const key = path[index];
+    if (index === path.length - 1) {
+      current[key] = value;
+      return;
+    }
+
+    if (!current[key] || typeof current[key] !== 'object') {
+      current[key] = {};
+    }
+    current = current[key];
+  }
+}
+
+function sanitizeId(value, fallback) {
+  if (!value || typeof value !== 'string') {
+    return fallback;
+  }
+  return value.trim().replace(/\s+/g, '-').replace(/[^a-zA-Z0-9-_]/g, '').toLowerCase() || fallback;
+}
+
+function buildRuntimeDataFromState(state) {
+  if (!state || !Array.isArray(state.scenes)) {
+    return { scenes: [], interactions: [], texts: {}, order: [] };
+  }
+
+  const scenes = [];
+  const interactions = [];
+  const texts = {};
+  const order = [];
+  const dialogueLookup = new Map();
+
+  state.scenes.forEach((entry, sceneIndex) => {
+    if (!entry || !entry.data) {
+      return;
+    }
+
+    const sceneName = entry.name || entry.data?.name;
+    if (!sceneName) {
+      return;
+    }
+
+    const sceneData = deepClone(entry.data);
+    sceneData.name = sceneName;
+    scenes.push({ name: sceneName, data: sceneData });
+    order.push(sceneName);
+
+    const dialogues = Array.isArray(entry.dialogues) ? entry.dialogues : [];
+    dialogues.forEach((dialogue, dialogueIndex) => {
+      if (!dialogue || typeof dialogue !== 'object') {
+        return;
+      }
+
+      const fallbackId = `dialogue-${sceneIndex + 1}-${dialogueIndex + 1}`;
+      const dialogueId = sanitizeId(dialogue.id, fallbackId);
+      const text = typeof dialogue.text === 'string' ? dialogue.text : '';
+      const textKeyPath = ['builder', 'dialogues', sceneName, dialogueId];
+
+      setNestedValue(texts, textKeyPath, text);
+
+      dialogueLookup.set(`${sceneName}:${dialogueId}`, {
+        textKey: textKeyPath.join('.'),
+        speaker: dialogue.speaker || 'me',
+        duration: dialogue.duration,
+        isThought: Boolean(dialogue.isThought),
+        anchor: dialogue.anchor || null,
+      });
+    });
+
+    const interactionEntries = Array.isArray(entry.interactions) ? entry.interactions : [];
+    interactionEntries.forEach((interaction, interactionIndex) => {
+      if (!interaction || typeof interaction !== 'object') {
+        return;
+      }
+
+      const { verb, target, dialogueId } = interaction;
+      if (!verb || !target || !dialogueId) {
+        return;
+      }
+
+      const lookupKey = `${sceneName}:${sanitizeId(dialogueId, dialogueId)}`;
+      const dialogueConfig = dialogueLookup.get(lookupKey);
+      if (!dialogueConfig) {
+        return;
+      }
+
+      const outcomeKey = `builder_${sceneName}_${interactionIndex}`;
+
+      interactions.push({
+        id: interaction.id || outcomeKey,
+        scene: sceneName,
+        verb,
+        target,
+        dialogues: {
+          response: {
+            speaker: dialogueConfig.speaker,
+            textKey: dialogueConfig.textKey,
+            duration: dialogueConfig.duration,
+            isThought: dialogueConfig.isThought,
+          },
+        },
+        action: () => 'response',
+        conditions: [],
+      });
+    });
+  });
+
+  return { scenes, interactions, texts, order };
+}
+
+export function getBuilderRuntimeData() {
+  try {
+    const state = loadBuilderState();
+    return buildRuntimeDataFromState(state);
+  } catch (error) {
+    console.warn('Failed to load builder runtime data:', error);
+    return { scenes: [], interactions: [], texts: {}, order: [] };
+  }
+}
+
+export function getDialogueAnchor({ sceneName, dialogueId }) {
+  const state = loadBuilderState();
+  if (!state || !Array.isArray(state.scenes)) {
+    return null;
+  }
+
+  const sceneEntry = state.scenes.find((entry) => entry.name === sceneName);
+  if (!sceneEntry) {
+    return null;
+  }
+
+  const dialogue = (sceneEntry.dialogues || []).find((item) => item.id === dialogueId);
+  if (!dialogue) {
+    return null;
+  }
+
+  return dialogue.anchor || null;
+}

--- a/src/scripts/builder/storage.js
+++ b/src/scripts/builder/storage.js
@@ -1,0 +1,161 @@
+const STORAGE_KEY = 'camel-game-builder-state';
+const STATE_VERSION = 1;
+
+function deepClone(value) {
+  if (typeof structuredClone === 'function') {
+    try {
+      return structuredClone(value);
+    } catch (error) {
+      // Fall through to JSON method
+    }
+  }
+
+  return JSON.parse(JSON.stringify(value));
+}
+
+function normalizeScene(scene) {
+  if (!scene || typeof scene !== 'object') {
+    return null;
+  }
+
+  const name = scene.name || scene.id || null;
+  if (!name) {
+    return null;
+  }
+
+  const data = deepClone(scene);
+  data.name = name;
+
+  return {
+    id: name,
+    name,
+    data,
+    dialogues: [],
+    interactions: [],
+  };
+}
+
+export function loadBuilderState() {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return null;
+  }
+
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') {
+      return null;
+    }
+
+    if (parsed.version && parsed.version !== STATE_VERSION) {
+      return parsed;
+    }
+
+    return parsed;
+  } catch (error) {
+    console.warn('Failed to parse builder state from localStorage:', error);
+    return null;
+  }
+}
+
+export function saveBuilderState(state) {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return false;
+  }
+
+  try {
+    const payload = {
+      version: STATE_VERSION,
+      updatedAt: Date.now(),
+      ...deepClone(state),
+    };
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    return true;
+  } catch (error) {
+    console.warn('Failed to save builder state to localStorage:', error);
+    return false;
+  }
+}
+
+export function createInitialStateFromScenes(scenes) {
+  const entries = [];
+
+  if (Array.isArray(scenes)) {
+    scenes.forEach((scene) => {
+      const entry = normalizeScene(scene);
+      if (entry) {
+        entries.push(entry);
+      }
+    });
+  } else if (scenes && typeof scenes === 'object') {
+    Object.values(scenes).forEach((scene) => {
+      const entry = normalizeScene(scene);
+      if (entry) {
+        entries.push(entry);
+      }
+    });
+  }
+
+  return {
+    version: STATE_VERSION,
+    updatedAt: Date.now(),
+    scenes: entries,
+  };
+}
+
+export function upsertSceneEntry({ state, scene }) {
+  if (!state || !scene) {
+    return state;
+  }
+
+  const existingIndex = state.scenes.findIndex((entry) => entry.id === scene.id);
+  if (existingIndex >= 0) {
+    state.scenes[existingIndex] = deepClone(scene);
+  } else {
+    state.scenes.push(deepClone(scene));
+  }
+
+  return state;
+}
+
+export function deleteSceneEntry({ state, id }) {
+  if (!state || !id) {
+    return state;
+  }
+
+  state.scenes = state.scenes.filter((entry) => entry.id !== id);
+  return state;
+}
+
+export function reorderSceneEntries({ state, fromIndex, toIndex }) {
+  if (!state || !Array.isArray(state.scenes)) {
+    return state;
+  }
+
+  const scenes = state.scenes;
+  if (
+    fromIndex < 0 ||
+    fromIndex >= scenes.length ||
+    toIndex < 0 ||
+    toIndex >= scenes.length ||
+    fromIndex === toIndex
+  ) {
+    return state;
+  }
+
+  const [moved] = scenes.splice(fromIndex, 1);
+  scenes.splice(toIndex, 0, moved);
+  state.scenes = scenes;
+  return state;
+}
+
+export function cloneBuilderState(state) {
+  return deepClone(state);
+}
+
+export { STORAGE_KEY as BUILDER_STORAGE_KEY, STATE_VERSION as BUILDER_STATE_VERSION };

--- a/src/scripts/scenes/index.js
+++ b/src/scripts/scenes/index.js
@@ -1,9 +1,37 @@
+import { getBuilderRuntimeData } from '../builder/runtime.js';
 import { desertScene } from './desert.js';
 import { teaScene } from './tea.js';
 
+const defaultScenes = [desertScene, teaScene];
+
+function buildSceneMap(entries) {
+  const map = {};
+  entries.forEach((entry) => {
+    if (!entry || !entry.name || !entry.data) {
+      return;
+    }
+    map[entry.name] = entry.data;
+  });
+  return map;
+}
+
+const builderData = getBuilderRuntimeData();
+const builderScenes = buildSceneMap(builderData.scenes || []);
+
 const scenes = {
-  desert: desertScene,
-  tea: teaScene,
+  ...defaultScenes.reduce((accumulator, scene) => {
+    if (scene?.name) {
+      accumulator[scene.name] = scene;
+    }
+    return accumulator;
+  }, {}),
+  ...builderScenes,
 };
 
-export { desertScene, teaScene, scenes };
+const sceneOrder = builderData.order && builderData.order.length
+  ? builderData.order
+  : defaultScenes.map((scene) => scene.name).filter(Boolean);
+
+const initialSceneName = sceneOrder.length ? sceneOrder[0] : desertScene.name;
+
+export { desertScene, teaScene, scenes, sceneOrder, initialSceneName };

--- a/src/scripts/texts.js
+++ b/src/scripts/texts.js
@@ -1,4 +1,6 @@
-export const TEXTS = {
+import { getBuilderRuntimeData } from './builder/runtime.js';
+
+const DEFAULT_TEXTS = {
   camel: {},
   me: {
     initialObservation: 'The desert is quiet.',
@@ -56,6 +58,38 @@ export const TEXTS = {
     },
   },
 };
+
+function deepMerge(target, source) {
+  if (!source || typeof source !== 'object') {
+    return target;
+  }
+
+  const output = { ...target };
+
+  Object.keys(source).forEach((key) => {
+    const sourceValue = source[key];
+    const targetValue = output[key];
+
+    if (Array.isArray(sourceValue)) {
+      output[key] = sourceValue.slice();
+      return;
+    }
+
+    if (sourceValue && typeof sourceValue === 'object') {
+      output[key] = deepMerge(targetValue && typeof targetValue === 'object' ? targetValue : {}, sourceValue);
+      return;
+    }
+
+    output[key] = sourceValue;
+  });
+
+  return output;
+}
+
+const builderData = getBuilderRuntimeData();
+const TEXTS = deepMerge(DEFAULT_TEXTS, builderData.texts || {});
+
+export { TEXTS };
 
 export function getText(path) {
   const value = path

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -16,6 +16,15 @@ body {
   box-sizing: border-box;
 }
 
+body[data-mode='builder'] {
+  background: #f5f1e6;
+  overflow: auto;
+  min-height: 100vh;
+  height: auto;
+  display: block;
+  padding: 0;
+}
+
 .is-hidden {
   display: none !important;
 }
@@ -89,6 +98,30 @@ body {
   box-sizing: border-box;
   gap: 0;
   align-items: stretch;
+}
+
+.menu-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.25rem var(--app-gutter);
+  background: rgba(0, 0, 0, 0.15);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.3);
+}
+
+.menu-toolbar__label {
+  font-weight: bold;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+}
+
+.menu-toolbar__select {
+  flex: 0 0 auto;
+  padding: 0.25rem 0.5rem;
+  font-family: inherit;
+  border: 1px solid rgba(0, 0, 0, 0.4);
+  background: rgba(255, 255, 255, 0.85);
 }
 
 .ambient {
@@ -176,6 +209,457 @@ body {
 .label[data-name="camel"] {
   background: #e2b980;
   color: #2a1b0a;
+}
+
+#builder-root {
+  min-height: 100vh;
+  background: #f5f1e6;
+  color: #2f2b28;
+  font-family: 'Courier New', monospace;
+  padding: clamp(1.5rem, 3vw, 2.5rem);
+  box-sizing: border-box;
+}
+
+body[data-mode='builder'] #game,
+body[data-mode='builder'] #menu,
+body[data-mode='builder'] #intro-sequence {
+  display: none !important;
+}
+
+.builder-app {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  gap: clamp(1rem, 2vw, 1.5rem);
+  min-height: 80vh;
+}
+
+.builder-app__sidebar {
+  background: #faf6ee;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 12px;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.08);
+}
+
+.builder-sidebar__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.builder-sidebar__header h1 {
+  margin: 0;
+  font-size: 1.45rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.builder-status {
+  font-size: 0.85rem;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.builder-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.builder-section__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.builder-section__header h2 {
+  margin: 0;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.builder-scene-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.builder-scene-list__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.builder-scene-list__button {
+  flex: 1 1 auto;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.8);
+  font-family: inherit;
+  font-size: 0.95rem;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.builder-scene-list__button:hover {
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.builder-scene-list__button.is-active {
+  background: #2f2b28;
+  color: #f5f1e6;
+  border-color: #2f2b28;
+}
+
+.builder-scene-list__controls {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.builder-button,
+.builder-icon-button {
+  font-family: inherit;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background: rgba(255, 255, 255, 0.85);
+  color: inherit;
+  padding: 0.35rem 0.75rem;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s, box-shadow 0.2s;
+}
+
+.builder-button:hover,
+.builder-icon-button:hover {
+  background: rgba(255, 255, 255, 1);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.builder-button:disabled,
+.builder-icon-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.builder-button--primary {
+  background: #2f2b28;
+  color: #f5f1e6;
+  border-color: #2f2b28;
+}
+
+.builder-button--primary:hover {
+  background: #443d39;
+}
+
+.builder-button--danger,
+.builder-icon-button--danger {
+  border-color: #a33131;
+  color: #a33131;
+}
+
+.builder-button--danger:hover,
+.builder-icon-button--danger:hover {
+  background: rgba(163, 49, 49, 0.12);
+}
+
+.builder-icon-button {
+  padding: 0.25rem 0.5rem;
+  font-size: 0.85rem;
+}
+
+.builder-app__main {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.builder-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.8);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+}
+
+.builder-toolbar__group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.builder-canvas-wrapper {
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  padding: 1rem;
+  position: relative;
+}
+
+.builder-canvas {
+  position: relative;
+  width: 100%;
+  max-width: 960px;
+  height: auto;
+  aspect-ratio: 960 / 540;
+  background: repeating-linear-gradient(
+      0deg,
+      rgba(0, 0, 0, 0.04),
+      rgba(0, 0, 0, 0.04) 1px,
+      transparent 1px,
+      transparent 32px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(0, 0, 0, 0.04),
+      rgba(0, 0, 0, 0.04) 1px,
+      transparent 1px,
+      transparent 32px
+    ),
+    #fefcf6;
+  border-radius: 10px;
+  overflow: hidden;
+  cursor: crosshair;
+}
+
+.builder-canvas.is-empty::after {
+  content: 'Click "Draw rectangle" to add components';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.1rem;
+  color: rgba(0, 0, 0, 0.35);
+  pointer-events: none;
+}
+
+.builder-label {
+  position: absolute;
+  border: 2px solid rgba(0, 0, 0, 0.7);
+  border-radius: 6px;
+  padding: 0.35rem 0.5rem;
+  background: rgba(255, 255, 255, 0.9);
+  color: #1f1c1a;
+  font-size: 0.95rem;
+  font-weight: bold;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  cursor: move;
+  user-select: none;
+}
+
+.builder-label.is-selected {
+  border-color: #2f2b28;
+  box-shadow: 0 0 0 2px rgba(47, 43, 40, 0.2), 0 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+.builder-label__handle {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  bottom: -6px;
+  right: -6px;
+  border-radius: 50%;
+  background: #2f2b28;
+  border: 2px solid #f5f1e6;
+  cursor: se-resize;
+}
+
+.builder-panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: clamp(1rem, 2vw, 1.5rem);
+}
+
+.builder-panel {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.08);
+}
+
+.builder-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.builder-panel__header h3 {
+  margin: 0;
+  text-transform: uppercase;
+  font-size: 0.9rem;
+  letter-spacing: 0.08em;
+}
+
+.builder-panel__body {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  flex: 1 1 auto;
+}
+
+.builder-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.builder-form[data-empty='true'] {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.builder-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.builder-field--checkbox {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.builder-field__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.builder-field-group {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.builder-field-group .builder-field {
+  flex: 1 1 0;
+}
+
+.builder-input {
+  font-family: inherit;
+  font-size: 0.95rem;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  border-radius: 6px;
+  padding: 0.4rem 0.5rem;
+  background: rgba(255, 255, 255, 0.95);
+}
+
+.builder-input:focus {
+  outline: 2px solid rgba(47, 43, 40, 0.3);
+}
+
+.builder-input--compact {
+  min-width: 120px;
+}
+
+.builder-textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.builder-dialogue-layout {
+  display: grid;
+  grid-template-columns: 180px minmax(0, 1fr);
+  gap: 1rem;
+}
+
+.builder-dialogue-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.builder-dialogue-list__item {
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  background: rgba(255, 255, 255, 0.8);
+  cursor: pointer;
+  text-align: left;
+}
+
+.builder-dialogue-list__item.is-active {
+  background: #2f2b28;
+  color: #f5f1e6;
+}
+
+.builder-dialogue-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.builder-empty-state {
+  padding: 0.75rem;
+  border: 1px dashed rgba(0, 0, 0, 0.2);
+  border-radius: 8px;
+  text-align: center;
+  font-size: 0.9rem;
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.builder-interaction-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px dashed rgba(0, 0, 0, 0.08);
+}
+
+.builder-interaction-row:last-child {
+  border-bottom: none;
+}
+
+.builder-preview-layer {
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+}
+
+.builder-preview-anchor {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  left: 50%;
+  top: 8%;
+}
+
+.dialogue-box--builder {
+  position: absolute;
+  transform: translate(-50%, -100%);
+  padding: 0.5rem 0.75rem;
+  background: rgba(0, 0, 0, 0.75);
+  color: #f5f1e6;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+  white-space: pre-wrap;
+}
+
+.builder-button.is-active {
+  box-shadow: inset 0 0 0 2px rgba(47, 43, 40, 0.4);
 }
 
 @keyframes dashPath {


### PR DESCRIPTION
## Summary
- add an app entrypoint that routes between the game and a new scene builder UI
- implement a drag-and-drop scene builder with dialogue and interaction editors persisted in localStorage
- merge builder data into scenes, texts, and interactions while adding a scene selector to the game menu

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ea55d3e3fc832b8d10eaeedf5e755e